### PR TITLE
Number of items for shipping throwing errors

### DIFF
--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -373,7 +373,7 @@ class Product
     }
     public function setNumberItems($number)
     {
-        $this->pNumberItems = $number;
+        $this->pNumberItems = ($number != '' ? $number : null);
     }
     public function setCreatesUserAccount($bool)
     {


### PR DESCRIPTION
When adding a new product and, under shippin, leaving number of items empty, it would throw an error as the value sent would be an empty string ""

But that field is an integer AND is nullable but sending back an empty string made it neither null nor an integer.

This fixes that