### PR TITLE
Block interface enhancements

### DIFF
--- a/blocks/community_product/controller.php
+++ b/blocks/community_product/controller.php
@@ -13,7 +13,7 @@ class Controller extends BlockController
     protected $btTable = 'btCommunityStoreProduct';
     protected $btInterfaceWidth = "450";
     protected $btWrapperClass = 'ccm-ui';
-    protected $btInterfaceHeight = "520";
+    protected $btInterfaceHeight = "538";
     protected $btDefaultSet = 'community_store';
 
     public function getBlockTypeDescription()
@@ -86,5 +86,22 @@ class Controller extends BlockController
             }
         }
         parent::save($args);
+    }
+
+    public function add()
+    {
+        $this->requireAsset('css', 'select2');
+        $this->requireAsset('javascript', 'select2');
+    }
+    public function edit()
+    {
+        $this->requireAsset('css', 'select2');
+        $this->requireAsset('javascript', 'select2');
+
+        if ($this->pID) {
+            $this->set('product', StoreProduct::getByID($this->pID));
+        } else {
+            $this->set('product', false);
+        }
     }
 }

--- a/blocks/community_product/form.php
+++ b/blocks/community_product/form.php
@@ -1,74 +1,14 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
-<style type="text/css">
-    #product-search { position: relative; }
-    #product-search-results { position: absolute; z-index: 2; display: none; top: 57px; padding: 10px 20px;background: #fff; width: 100%; height: 90px; overflow-y: scroll; border: 1px solid #ccc; box-shadow: 0 0 10px #ccc; }
-    #product-search-results.active { display: block; }
-        #product-search-results ul { padding: 0; }
-        #product-search-results ul li { list-style: none; padding: 2px 5px; cursor: pointer; }
-        #product-search-results ul li:hover { background: #0088ff; color: #fff; }
-</style>
-<script type="text/javascript">
-$(function(){
-    //search accounts
-    $("input#productSearch").on("keyup", function(e) {
-
-        // Set Search String
-        var searchString = $(this).val();
-    
-        // Do Search
-        if(searchString.length > 0){
-            $("#product-search-results").addClass("active");
-            $.ajax({
-                type: "post",
-                url: "<?=\URL::to('/productfinder')?>",
-                data: {query: searchString},
-                success: function(html){
-                    $("ul#results-list").html(html);
-                    $("#product-search-results ul li").click(function(){
-                        var pID = $(this).attr('data-product-id'); 
-                        var productName = $(this).text();
-                        $("#pID").val(pID);
-                        $("#product-search-results").removeClass("active");
-                        $('#productSearch').val('');
-                        $("#selected-product").html(productName);
-                    });
-                    $("*:not(#product-search-results ul li)").click(function(){
-                        $("#product-search-results").removeClass("active");
-                    })
-                }
-            });
-            
-        }
-        else{
-            $("#product-search-results").removeClass("active");
-        }
-    });
-    
-    
-});  
-</script>
-
 <legend><?= t("Product")?></legend>
 
 <div class="form-group">
     <?= $form->label('productLocation', t('Product'))?>
-    <?= $form->select('productLocation', array('page' => t('Find product associated with this page'), 'search' => t('Search and select product')), $productLocation, array('onChange' => 'updateProductLocation();'))?>
+    <?= $form->select('productLocation', array('search' => t('A selected product'),'page' => t('Product associated with this page')), $productLocation, array('onChange' => 'updateProductLocation();'))?>
 </div>
 
 <div class="form-group" id="product-search">
     <?= $form->label('productSearch', 'Search for a product')?>
-    <?= $form->text('productSearch')?>
-    <?= $form->hidden('pID', $pID)?>
-    <div id="product-search-results">
-        <ul id="results-list">
-            
-        </ul>
-    </div>
-    <div class="alert alert-info">
-        <strong><?= t("Selected Product:")?></strong>
-        <span id="selected-product"></span>
-    </div>
-   
+    <input name="pID" id="product-select"  class="select2-select" style="width: 100%" placeholder="<?= t('Select Product') ?>" />
 </div>
 
 <legend><?= t("Display Options")?></legend>
@@ -125,12 +65,6 @@ $(function(){
                 <?= t('Show If Featured')?>
             </label>
         </div>
-<!--        <div class="checkbox">-->
-<!--            <label>-->
-<!--                --><?//= $form->checkbox('showGroups', 1, !isset($showGroups) ? false : $showGroups);?>
-<!--                --><?//= t('Show Product Groups')?>
-<!--            </label>-->
-<!--        </div>-->
         <div class="checkbox">
             <label>
                 <?= $form->checkbox('showDimensions', 1, $showDimensions);?>
@@ -166,4 +100,37 @@ $(function(){
         }
     };
     updateProductLocation();
+
+    $(document).ready(function () {
+
+        $("#product-select").select2({
+            ajax: {
+                url: "<?= \URL::to('/productfinder')?>",
+                dataType: 'json',
+                quietMillis: 250,
+                data: function (term, page) {
+                    return {
+                        q: term, // search term
+                    };
+                },
+                results: function (data) {
+                    var results = [];
+                    $.each(data, function(index, item){
+                        results.push({
+                            id: item.pID,
+                            text: item.name + (item.SKU ? ' (' + item.SKU + ')' : '')
+                        });
+                    });
+                    return {
+                        results: results
+                    };
+                },
+                cache: true
+            },
+            minimumInputLength: 2,
+            initSelection: function(element, callback) {
+                callback({id: <?= ($pID ? $pID : 0); ?>, text: '<?= ($product ? $product->getName() : '');?>' });
+            },
+        }).select2('val', []);;
+    });
 </script>

--- a/blocks/community_product_list/controller.php
+++ b/blocks/community_product_list/controller.php
@@ -12,9 +12,9 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Group\GroupList as StoreG
 class Controller extends BlockController
 {
     protected $btTable = 'btCommunityStoreProductList';
-    protected $btInterfaceWidth = "450";
+    protected $btInterfaceWidth = "800";
     protected $btWrapperClass = 'ccm-ui';
-    protected $btInterfaceHeight = "400";
+    protected $btInterfaceHeight = "600";
     protected $btDefaultSet = 'community_store';
 
     public function getBlockTypeDescription()
@@ -89,7 +89,7 @@ class Controller extends BlockController
             }
         }
 
-        $products->setItemsPerPage($this->maxProducts);
+        $products->setItemsPerPage($this->maxProducts > 0 ? $this->maxProducts : 1000);
         $products->setGroupIDs($this->getGroupFilters());
         $products->setFeatureType($this->showFeatured);
         $products->setShowOutOfStock($this->showOutOfStock);
@@ -133,6 +133,7 @@ class Controller extends BlockController
         $args['showButton'] = isset($args['showButton']) ? 1 : 0;
         $args['truncateEnabled'] = isset($args['truncateEnabled']) ? 1 : 0;
         $args['showPagination'] = isset($args['showPagination']) ? 1 : 0;
+        $args['maxProducts'] = isset($args['maxProducts']) ? $args['maxProducts'] : 0;
 
         $filtergroups = $args['filtergroups'];
         unset($args['filtergroups']);
@@ -155,16 +156,13 @@ class Controller extends BlockController
     {
         $e = Core::make("helper/validation/error");
         $nh = Core::make("helper/number");
-        if ($args['maxProducts'] < 1) {
-            $e->add(t('Max Number of Products must be at least 1'));
-        }
 
         if (($args['filter'] == 'page' || $args['filter'] == 'page_children') && $args['filterCID'] <= 0) {
             $e->add(t('A page must be selected'));
         }
 
-        if (!$nh->isInteger($args['maxProducts'])) {
-            $e->add(t('Max Number of Products must be a whole number'));
+        if ($args['maxProducts'] && !$nh->isInteger($args['maxProducts'])) {
+            $e->add(t('Number of Products must be a whole number'));
         }
 
         return $e;

--- a/blocks/community_product_list/form.php
+++ b/blocks/community_product_list/form.php
@@ -1,166 +1,171 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");?>
-<fieldset>
-    <legend><?= t('Product Arrangement')?></legend>
-    <?php
-        foreach($grouplist as $productgroup){
-            $productgroups[$productgroup->getGroupID()] = $productgroup->getGroupName();
-        }
-    ?>
-    <div class="row">
-        <div class="col-xs-12 col-sm-6">
+<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+
+<div class="row">
+
+    <div class="col-xs-6">
+
+        <fieldset>
+            <legend><?= t('Products') ?></legend>
+
             <div class="form-group">
-                <?= $form->label('filter',t('List Products'));?>
-                <?= $form->select('filter',array(
-                    'all'=>t("All"),
-                    'current'=>t('Under current page'),
-                    'current_children'=>t('Under current page and child pages'),
-                    'page'=>t('Under a specified page'),
-                    'page_children'=>t('Under a specified page and child pages')
-                ),$filter);?>
+                <?= $form->label('filter', t('List Products')); ?>
+                <?= $form->select('filter', array(
+                    'all' => '** ' . t("All") . ' **',
+                    'current' => t('Under current page'),
+                    'current_children' => t('Under current page and child pages'),
+                    'page' => t('Under a specified page'),
+                    'page_children' => t('Under a specified page and child pages')
+                ), $filter); ?>
             </div>
 
             <div class="form-group" id="pageselector">
-                <div class="form-group" <?= ($filter == 'page' || $filter == 'page_children' ? '' : 'style="display: none"'); ?> >
+                <div
+                    class="form-group" <?= ($filter == 'page' || $filter == 'page_children' ? '' : 'style="display: none"'); ?> >
                     <?php
                     $ps = Core::make('helper/form/page_selector');
-                    echo $ps->selectPage('filterCID', ($filterCID > 0 ? $filterCID : false) ); ?>
+                    echo $ps->selectPage('filterCID', ($filterCID > 0 ? $filterCID : false)); ?>
                 </div>
             </div>
 
-        </div>
-        <div class="col-xs-12 col-sm-6">
-        	<div class="form-group">
-                <?= $form->label('sortOrder',t('Sort Order'));?>
-                <?= $form->select('sortOrder',array('alpha'=>t("Alphabetical"),'date'=>t('Recently Added'),'popular'=>t('Most Popular')),$sortOrder);?>
-            </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <?php if(!empty($productgroups)){?>
-        <div class="col-xs-12 col-sm-6">
             <div class="form-group">
-                <?= $form->label('gID',t('Filter by Groups'));?>
+                <?= $form->label('sortOrder', t('Sort Order')); ?>
+                <?= $form->select('sortOrder', array('alpha' => t("Alphabetical"), 'date' => t('Recently Added'), 'popular' => t('Most Popular')), $sortOrder); ?>
+            </div>
 
-                <div class="ccm-search-field-content ccm-search-field-content-select2">
-                    <select multiple="multiple" name="filtergroups[]" id="groups-select" class="existing-select2 select2-select" style="width: 100%">
-                        <?php foreach ($productgroups as $pgkey=>$pglabel) { ?>
-                            <option value="<?= $pgkey;?>" <?= (in_array($pgkey, $groupfilters) ? 'selected="selected"' : ''); ?>><?= $pglabel; ?></option>
-                        <?php } ?>
-                    </select>
+        </fieldset>
+
+        <fieldset>
+            <legend><?= t('Filtering') ?></legend>
+
+            <?php
+            foreach ($grouplist as $productgroup) {
+                $productgroups[$productgroup->getGroupID()] = $productgroup->getGroupName();
+            }
+            ?>
+
+            <?php if (!empty($productgroups)) { ?>
+
+                <div class="form-group">
+                    <?= $form->label('gID', t('Filter by Product Groups')); ?>
+
+                    <div class="ccm-search-field-content ccm-search-field-content-select2">
+                        <select multiple="multiple" name="filtergroups[]" id="groups-select"
+                                class="existing-select2 select2-select" style="width: 100%" placeholder="<?= t('Select Product Groups') ?>">
+                            <?php foreach ($productgroups as $pgkey => $pglabel) { ?>
+                                <option
+                                    value="<?= $pgkey; ?>" <?= (in_array($pgkey, $groupfilters) ? 'selected="selected"' : ''); ?>><?= $pglabel; ?></option>
+                            <?php } ?>
+                        </select>
+                    </div>
                 </div>
+
+
+                <div class="form-group">
+                    <?= $form->label('groupMatchAny', t('Matching')); ?>
+                    <?= $form->select('groupMatchAny', array('0' => t("All groups selected"), '1' => t('Any group selected')), $groupMatchAny); ?>
+                </div>
+
+            <?php } ?>
+
+
+            <div class="form-group radio">
+                <label>
+                    <?= $form->radio('showFeatured', 'all', $showFeatured == 'all' || !isset($showFeatured) ? true : false); ?>
+                    <?= t('Show Both Featured &amp; Non-featured') ?>
+                </label>
             </div>
-        </div>
+            <div class="form-group radio">
+                <label>
+                    <?= $form->radio('showFeatured', 'featured', $showFeatured == 'featured' ? true : false); ?>
+                    <?= t('Show Featured Only') ?>
+                </label>
+            </div>
+            <div class="form-group radio">
+                <label>
+                    <?= $form->radio('showFeatured', 'nonfeatured', $showFeatured == 'nonfeatured' ? true : false); ?>
+                    <?= t('Show Non-Featured Only') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showOutOfStock', 1, $showOutOfStock); ?>
+                    <?= t('Show Out of Stock Products') ?>
+                </label>
+            </div>
+        </fieldset>
 
-        <?php } ?>
 
-        <div class="col-xs-12 col-sm-6">
+    </div>
+    <div class="col-xs-6">
+        <fieldset>
+            <legend><?= t('Number and Pagination') ?></legend>
+
             <div class="form-group">
-                <?= $form->label('groupMatchAny',t('Matching'));?>
-                <?= $form->select('groupMatchAny',array('0'=>t("All groups listed"),'1'=>t('Any group listed')),$groupMatchAny);?>
+                <?= $form->label('maxProducts', t('Number of Products to Display')); ?>
+                <?= $form->number('maxProducts', $maxProducts, array('min'=>'0', 'step'=>'1','placeholder'=>t('leave blank or 0 to list all matching products'))); ?>
             </div>
-        </div>
 
-    </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showPagination', 1, $showPagination); ?>
+                    <?= t('Display pagination interface if more products are available than are displayed.') ?>
+                </label>
+            </div>
 
 
-    <legend><?= t('Pagination')?></legend>
-    <div class="row">
-        <div class="col-xs-6">
+        </fieldset>
+
+        <fieldset>
+            <legend><?= t('Display Options') ?></legend>
             <div class="form-group">
-                <?= $form->label('productsPerRow',t('Products per Row')); ?>
-                <?= $form->select('productsPerRow', array(1=>1,2=>2,3=>3,4=>4),$productsPerRow?$productsPerRow:1, array('style'=>'width:70px')); ?>
+                <?= $form->label('productsPerRow', t('Products per Row')); ?>
+                <?= $form->select('productsPerRow', array(1 => 1, 2 => 2, 3 => 3, 4 => 4), $productsPerRow ? $productsPerRow : 1); ?>
             </div>
-        </div>
-        <div class="col-xs-6">
-            <div class="form-group">
-                <?= $form->label('maxProducts',t('Max Number of Products')); ?>
-                <?= $form->text('maxProducts', isset($maxProducts)?$maxProducts:"10", array('style'=>'width:50px')); ?>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showAddToCart', 1, $showAddToCart); ?>
+                    <?= t('Add to Cart Button') ?>
+                </label>
             </div>
-        </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showPageLink', 1, $showPageLink); ?>
+                    <?= t('Page Link') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showDescription', 1, $showDescription); ?>
+                    <?= t('Product Description') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?php if ($showQuickViewLink != 0) {
+                        $showQuickViewLink = 1;
+                    } ?>
+                    <?= $form->checkbox('showQuickViewLink', 1, $showQuickViewLink); ?>
+                    <?= t('Quickview Link (Modal Window)') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showQuantity', 1, $showQuantity); ?>
+                    <?= t('Quantity Selector') ?>
+                </label>
+            </div>
+        </fieldset>
     </div>
-    <div class="checkbox">
-        <label>
-            <?= $form->checkbox('showPagination',1,$showPagination);?>
-            <?= t('Show Pagination')?>
-        </label>
-    </div>  
-    
-    <legend><?= t('Display Options')?></legend>
-    
-    <div class="checkbox">
-        <label>
-            <?= $form->checkbox('showOutOfStock',1,$showOutOfStock);?>
-            <?= t('Show Out of Stock Products')?>
-        </label>
-    </div>
-    
-    <label><?= t('Show Featured')?></label>
-    
-    <div class="radio">
-        <label>
-            <?= $form->radio('showFeatured','all',$showFeatured=='all' || !isset($showFeatured)?true:false);?>
-            <?= t('Show Both Featured &amp; Non-featured')?>
-        </label>
-    </div>
-    <div class="radio">
-        <label>
-            <?= $form->radio('showFeatured','featured',$showFeatured=='featured'?true:false);?>
-            <?= t('Featured Only')?>
-        </label>
-    </div>
-    <div class="radio">
-        <label>
-            <?= $form->radio('showFeatured','nonfeatured',$showFeatured=='nonfeatured'?true:false);?>
-            <?= t('Non-Featured Only')?>
-        </label>
-    </div>
-    
-    <label><?= t('Show:')?></label>
-    <div class="checkbox">
-        <label>
-            <?= $form->checkbox('showAddToCart',1,$showAddToCart);?>
-            <?= t('Add to Cart Button')?>
-        </label>
-    </div>
-    <div class="checkbox">
-        <label>
-            <?= $form->checkbox('showPageLink',1,$showPageLink);?>
-            <?= t('Page Link')?>
-        </label>
-    </div>
-    <div class="checkbox">
-        <label>
-            <?= $form->checkbox('showDescription',1,$showDescription);?>
-            <?= t('Description')?>
-        </label>
-    </div>
-    <div class="checkbox">
-        <label>
-            <?php if($showQuickViewLink!=0){
-                $showQuickViewLink=1;
-            }?>
-            <?= $form->checkbox('showQuickViewLink',1,$showQuickViewLink);?>
-            <?= t('Quickview Link (Modal Window)')?>
-        </label>
-    </div>
-    <div class="checkbox">
-        <label>
-            <?= $form->checkbox('showQuantity',1,$showQuantity);?>
-            <?= t('Show Quantity Selector')?>
-        </label>
-    </div>
-</fieldset>
-
+</div>
 
 <script>
-    $(document).ready(function(){
+    $(document).ready(function () {
         $('#groups-select').select2();
 
-        $('#filter').change(function(){
+        $('#filter').change(function () {
             if ($(this).val() == 'page' || $(this).val() == 'page_children') {
                 $('#pageselector>div').show();
-            }  else {
+            } else {
                 $('#pageselector>div').hide();
             }
         });

--- a/controller.php
+++ b/controller.php
@@ -15,7 +15,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '5.7.5';
-    protected $pkgVersion = '0.9.7.6';
+    protected $pkgVersion = '0.9.7.7';
 
     public function getPackageDescription()
     {

--- a/src/CommunityStore/Utilities/ProductFinder.php
+++ b/src/CommunityStore/Utilities/ProductFinder.php
@@ -16,26 +16,22 @@ class ProductFinder extends Controller
             echo "Access Denied";
             exit;
         }
-        if (!$_POST['query']) {
+        if (!$_GET['q']) {
             echo "Access Denied";
             exit;
         } else {
-            $query = $_POST['query'];
+            $query = $_GET['q'];
             $db = \Database::connection();
-            $results = $db->query('SELECT * FROM CommunityStoreProducts WHERE pName LIKE "%'.$query.'%"');
+            $results = $db->query('SELECT * FROM CommunityStoreProducts WHERE pName LIKE ? OR pSKU LIKE ? ', array('%'. $query . '%','%'. $query . '%'));
+            $resultsArray = array();
 
             if ($results) {
                 foreach ($results as $result) {
-                    ?>
-        
-                <li data-product-id="<?= $result['pID']?>"><?= $result['pName']?></li>
-        
-            <?php 
-                } //for each
-            } else { //if no results ?>
-                <li><?= t("I can't find a product by that name")?></li>
-            <?php 
+                    $resultsArray[] = array('pID'=> $result['pID'], 'name'=>$result['pName'], 'SKU'=>$result['pSKU']);
+                }
             }
+            echo json_encode($resultsArray);
         }
     }
 }
+


### PR DESCRIPTION
The Product List block add/edit dialog has been made bigger, with a re-arrangement of fields in hopefully a more logical way. 

The Product block has been updated to use a select2 picker to find the product.
The related productfinder function has been swapped over to output json as well as allow searches by SKU

Instead of committing this directly I've done it as a PR, in case anyone has any further suggestions for improvement. 

![screen shot 2016-03-19 at 3 45 59 pm](https://cloud.githubusercontent.com/assets/1079600/13896796/0181be90-edea-11e5-8d11-197831571653.png)
![screen shot 2016-03-19 at 3 46 14 pm](https://cloud.githubusercontent.com/assets/1079600/13896797/05740a9e-edea-11e5-8b60-15fdc9addfbf.png)
