### PR TITLE
Shipping instructions

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -15,7 +15,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '5.7.5';
-    protected $pkgVersion = '0.9.7.8';
+    protected $pkgVersion = '0.9.7.9';
 
     public function getPackageDescription()
     {

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -127,6 +127,7 @@ class Checkout extends PageController
         $this->set('shippingtotal',$totals['shippingTotal']);
         $this->set('total',$totals['total']);
         $this->set('shippingEnabled', StoreCart::isShippable());
+        $this->set('shippingInstructions', StoreCart::getShippingInstructions());
 
         $this->requireAsset('javascript', 'jquery');
         $js = \Concrete\Package\CommunityStore\Controller::returnHeaderJS();
@@ -158,6 +159,7 @@ class Checkout extends PageController
     
     public function failed()
     {
+        $this->set('shippingInstructions', StoreCart::getShippingInstructions());
         $this->set('paymentErrors',Session::get('paymentErrors'));
         $this->set('activeShippingLabel', StoreShippingMethod::getActiveShippingLabel());
         $this->set('shippingTotal', StoreCalculator::getShippingTotal());

--- a/controllers/single_page/dashboard/store/orders.php
+++ b/controllers/single_page/dashboard/store/orders.php
@@ -51,6 +51,8 @@ class Orders extends DashboardPageController
         } else {
             $this->redirect('/dashboard/store/orders');
         }
+
+        $this->set('pageTitle', t("Order #") . $order->getOrderID());
     }
     public function removed()
     {

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -69,6 +69,7 @@ class Settings extends DashboardPageController
                 Config::save('community_store.shippingitem',$args['shippingItemPrice']);
                 Config::save('community_store.weightUnit',$args['weightUnit']);
                 Config::save('community_store.sizeUnit',$args['sizeUnit']);
+                Config::save('community_store.deliveryInstructions',$args['deliveryInstructions']);
                 Config::save('community_store.notificationemails',$args['notificationEmails']);
                 Config::save('community_store.emailalerts',$args['emailAlert']);
                 Config::save('community_store.emailalertsname',$args['emailAlertName']);

--- a/elements/checkout/shipping_methods.php
+++ b/elements/checkout/shipping_methods.php
@@ -5,7 +5,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingM
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as StorePrice;
 
 $eligibleMethods = StoreShippingMethod::getEligibleMethods();
-$currentShippingID = Session::get('smID');
+$currentShippingID = Session::get('community_store.smID');
 $count=0;
 ?>
 

--- a/elements/order_slip.php
+++ b/elements/order_slip.php
@@ -7,6 +7,7 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
 <link href="/concrete/css/app.css" rel="stylesheet" type="text/css" media="all">
 <div class="ccm-ui">
     <div class="container">
+        <h1><?= t("Order #") . $order->getOrderID() ?></h1>
         <h3><?= t("Customer Overview") ?></h3>
         <hr>
 
@@ -125,8 +126,18 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
         <p>
             <strong><?= t("Payment Method") ?>: </strong><?= t($order->getPaymentMethodName()) ?><br>
             <?php if ($order->isShippable()) { ?>
-            <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?>
-            <?php } ?>
+            <br><strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?>
+
+            <?php
+            $shippingInstructions = $order->getShippingInstructions();
+            if ($shippingInstructions) { ?>
+        <p>
+            <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?>
+        </p>
+        <?php } ?>
+
+
+        <?php } ?>
         </p>
 
     </div>

--- a/js/community-store.js
+++ b/js/community-store.js
@@ -421,10 +421,13 @@ $(document).ready(function () {
             var smID = $("#store-checkout-shipping-method-options input[type='radio']:checked").val();
             var methodText = $.trim($("#store-checkout-shipping-method-options input[type='radio']:checked").parent().find('.store-shipping-details').html());
             obj.find('.summary-shipping-method').html(methodText);
+            var sInstructions = $('#store-checkout-shipping-instructions').val();
+            obj.find('.summary-shipping-instructions').html(sInstructions);
 
             $.ajax({
                 type: 'post',
-                data: {smID: smID},
+                data: { smID: smID,
+                        sInstructions: sInstructions},
                 url: CARTURL + "/getShippingTotal",
                 success: function (total) {
                     if (total <= 0) {

--- a/mail/new_order_notification.php
+++ b/mail/new_order_notification.php
@@ -106,6 +106,7 @@ ob_start();
     </tbody>
 </table>
 
+<p>
     <?php if ($order->isShippable()) { ?>
         <strong><?= t("Shipping") ?>:</strong>  <?= StorePrice::format($order->getShippingTotal()) ?><br>
         <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?> <br>

--- a/mail/new_order_notification.php
+++ b/mail/new_order_notification.php
@@ -108,10 +108,13 @@ ob_start();
 
     <?php if ($order->isShippable()) { ?>
         <strong><?= t("Shipping") ?>:</strong>  <?= StorePrice::format($order->getShippingTotal()) ?><br>
-    <?php } ?>
-
-    <?php if ($order->isShippable()) { ?>
         <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?> <br>
+
+        <?php
+        $shippingInstructions = $order->getShippingInstructions();
+        if ($shippingInstructions) { ?>
+            <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?> <br />
+        <?php } ?>
     <?php } ?>
 
     <?php $applieddiscounts = $order->getAppliedDiscounts();

--- a/mail/order_receipt.php
+++ b/mail/order_receipt.php
@@ -134,9 +134,31 @@ if (count($downloads) > 0) {
 <?php } ?>
 
 <p>
+
     <?php if ($order->isShippable()) { ?>
-        <strong><?= t("Shipping") ?>:</strong>  <?= Price::format($order->getShippingTotal()) ?><br>
+        <strong><?= t("Shipping") ?>:</strong>  <?= StorePrice::format($order->getShippingTotal()) ?><br>
         <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?> <br>
+
+        <?php
+        $shippingInstructions = $order->getShippingInstructions();
+        if ($shippingInstructions) { ?>
+            <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?> <br />
+        <?php } ?>
+    <?php } ?>
+
+    <?php if ($order->isShippable()) { ?>
+        <br><strong><?= t("Shipping") ?>:</strong>  <?= StorePrice::format($order->getShippingTotal()) ?><br>
+
+        <?php if ($order->isShippable()) { ?>
+            <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?> <br>
+
+            <?php
+            $shippingInstructions = $order->getShippingInstructions();
+            if ($shippingInstructions) { ?>
+                <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?> <br />
+            <?php } ?>
+        <?php } ?>
+
     <?php } ?>
 
     <?php $applieddiscounts = $order->getAppliedDiscounts();

--- a/mail/order_receipt.php
+++ b/mail/order_receipt.php
@@ -1,6 +1,6 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as Price;
+use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as StorePrice;
 
 $subject = t("Order Receipt");
 
@@ -95,8 +95,8 @@ ob_start();
                     ?>
                 </td>
                 <td><?= $item->getQty() ?></td>
-                <td><?= Price::format($item->getPricePaid()) ?></td>
-                <td><?= Price::format($item->getSubTotal()) ?></td>
+                <td><?= StorePrice::format($item->getPricePaid()) ?></td>
+                <td><?= StorePrice::format($item->getSubTotal()) ?></td>
             </tr>
             <?php
         }
@@ -134,7 +134,6 @@ if (count($downloads) > 0) {
 <?php } ?>
 
 <p>
-
     <?php if ($order->isShippable()) { ?>
         <strong><?= t("Shipping") ?>:</strong>  <?= StorePrice::format($order->getShippingTotal()) ?><br>
         <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?> <br>
@@ -144,21 +143,6 @@ if (count($downloads) > 0) {
         if ($shippingInstructions) { ?>
             <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?> <br />
         <?php } ?>
-    <?php } ?>
-
-    <?php if ($order->isShippable()) { ?>
-        <br><strong><?= t("Shipping") ?>:</strong>  <?= StorePrice::format($order->getShippingTotal()) ?><br>
-
-        <?php if ($order->isShippable()) { ?>
-            <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?> <br>
-
-            <?php
-            $shippingInstructions = $order->getShippingInstructions();
-            if ($shippingInstructions) { ?>
-                <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?> <br />
-            <?php } ?>
-        <?php } ?>
-
     <?php } ?>
 
     <?php $applieddiscounts = $order->getAppliedDiscounts();
@@ -176,10 +160,10 @@ if (count($downloads) > 0) {
 
     <?php foreach ($order->getTaxes() as $tax) { ?>
         <strong><?= $tax['label'] ?>
-            :</strong> <?= Price::format($tax['amount'] ? $tax['amount'] : $tax['amountIncluded']) ?><br>
+            :</strong> <?= StorePrice::format($tax['amount'] ? $tax['amount'] : $tax['amountIncluded']) ?><br>
     <?php } ?>
 
-    <strong class="text-large"><?= t("Total") ?>:</strong> <?= Price::format($order->getTotal()) ?><br><br>
+    <strong class="text-large"><?= t("Total") ?>:</strong> <?= StorePrice::format($order->getTotal()) ?><br><br>
     <strong><?= t("Payment Method") ?>: </strong><?= $order->getPaymentMethodName() ?>
 </p>
 </body>
@@ -226,8 +210,8 @@ if ($items) {
 }
 ?>
 
-<?= t("Tax") ?>: <?= Price::format($order->getTaxTotal()) ?>
-<?= t("Shipping") ?>:  <?= Price::format($order->getShippingTotal()) ?>
+<?= t("Tax") ?>: <?= StorePrice::format($order->getTaxTotal()) ?>
+<?= t("Shipping") ?>:  <?= StorePrice::format($order->getShippingTotal()) ?>
 <?php $applieddiscounts = $order->getAppliedDiscounts();
 if (!empty($applieddiscounts)) { ?>
     <?php
@@ -238,7 +222,7 @@ if (!empty($applieddiscounts)) { ?>
     echo (count($applieddiscounts) > 1 ? t('Discounts') : t('Discount')) . ' ' . implode(',', $discountsApplied);
     ?>
 <?php } ?>
-<?= t("Total") ?>: <?= Price::format($order->getTotal()) ?>
+<?= t("Total") ?>: <?= StorePrice::format($order->getTotal()) ?>
 
 <?php
 

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -259,6 +259,11 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as Store
                             <div id="store-checkout-shipping-method-options" data-error-message="<?= h(t('Please select a shipping method'));?>">
                             </div>
 
+                            <div class="form-group store-checkout-form-delivery-instructions">
+                                <label><?= t('Delivery Instructions'); ?></label>
+                                <?= $form->textarea('store-checkout-shipping-instructions', h($shippingInstructions)); ?>
+                            </div>
+
                             <div class="store-checkout-form-group-buttons">
                                 <a href="#" class="store-btn-previous-pane btn btn-default"><?= t("Previous") ?></a>
                                 <input type="submit" class="store-btn-next-pane btn btn-default pull-right" value="<?= t("Next") ?>">
@@ -274,6 +279,9 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as Store
                                 <div class="col-md-6">
                                     <div class="summary-shipping-method">
                                         <?= $activeShippingLabel; ?> - <?= $shippingTotal > 0 ? StorePrice::format($shippingTotal) : t('No Charge');?>
+                                    </div>
+                                    <div class="summary-shipping-instructions">
+                                        <?= h($shippingInstructions); ?>
                                     </div>
                                 </div>
                             </div>

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -259,10 +259,12 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as Store
                             <div id="store-checkout-shipping-method-options" data-error-message="<?= h(t('Please select a shipping method'));?>">
                             </div>
 
+                            <?php if (Config::get('community_store.deliveryInstructions')) { ?>
                             <div class="form-group store-checkout-form-delivery-instructions">
                                 <label><?= t('Delivery Instructions'); ?></label>
                                 <?= $form->textarea('store-checkout-shipping-instructions', h($shippingInstructions)); ?>
                             </div>
+                            <?php } ?>
 
                             <div class="store-checkout-form-group-buttons">
                                 <a href="#" class="store-btn-previous-pane btn btn-default"><?= t("Previous") ?></a>

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -181,10 +181,20 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
     </p>
 
     <?php if ($order->isShippable()) { ?>
-        <p>
+        <br /><p>
             <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?>
         </p>
+
+        <?php
+        $shippingInstructions = $order->getShippingInstructions();
+        if ($shippingInstructions) { ?>
+            <p>
+                <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?>
+            </p>
+        <?php } ?>
+
     <?php } ?>
+
 
     <br />
     <h3><?= t("Order Status History")?></h3>

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -81,6 +81,13 @@
                         </div>
                     </div>
 
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <label><?= $form->checkbox('deliveryInstructions', '1',Config::get('community_store.deliveryInstructions') ? '1' : '0')?>
+                                <?= t('Include Delivery Instructions field in checkout');?></label>
+                        </div>
+                    </div>
+
 
                 </div><!-- #settings-shipping -->
 

--- a/src/CommunityStore/Cart/Cart.php
+++ b/src/CommunityStore/Cart/Cart.php
@@ -394,4 +394,12 @@ class Cart
 
         return false;
     }
+
+    public static function setShippingInstructions($sInstructions) {
+        \Session::set('communitystore.sInstructions', $sInstructions);
+    }
+
+    public static function getShippingInstructions() {
+        return  \Session::get('communitystore.sInstructions');
+    }
 }

--- a/src/CommunityStore/Cart/CartTotal.php
+++ b/src/CommunityStore/Cart/CartTotal.php
@@ -16,6 +16,9 @@ class CartTotal extends RouteController
     public function getShippingTotal()
     {
         $smID = $_POST['smID'];
+        $sInstructions = $_POST['sInstructions'];
+
+        StoreCart::setShippingInstructions($sInstructions);
 
         $total = StoreCalculator::getShippingTotal($smID);
         if ($total>0) {

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -51,7 +51,7 @@ class Order
     /** @Column(type="text") */
     protected $smName;
 
-    /** @Column(type="text") */
+    /** @Column(type="text",nullable=true) */
     protected $sInstructions;
 
     /** @Column(type="decimal", precision=10, scale=2) * */

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -51,6 +51,9 @@ class Order
     /** @Column(type="text") */
     protected $smName;
 
+    /** @Column(type="text") */
+    protected $sInstructions;
+
     /** @Column(type="decimal", precision=10, scale=2) * */
     protected $oShippingTotal;
 
@@ -105,6 +108,11 @@ class Order
     public function setShippingMethodName($smName)
     {
         $this->smName = $smName;
+    }
+
+    public function setShippingInstructions($sInstructions)
+    {
+        $this->sInstructions = $sInstructions;
     }
 
     public function setShippingTotal($shippingTotal)
@@ -166,6 +174,11 @@ class Order
     public function getShippingMethodName()
     {
         return $this->smName;
+    }
+
+    public function getShippingInstructions()
+    {
+        return $this->sInstructions;
     }
 
     public function getShippingTotal()
@@ -281,6 +294,8 @@ class Order
         $customer = new StoreCustomer();
         $now = new \DateTime();
         $smName = StoreShippingMethod::getActiveShippingLabel();
+        $sInstructions = StoreCart::getShippingInstructions();
+        StoreCart::getShippingInstructions('');
         $shippingTotal = StoreCalculator::getShippingTotal();
         $taxes = StoreTax::getConcatenatedTaxStrings();
         $totals = StoreCalculator::getTotals();
@@ -292,6 +307,7 @@ class Order
         $order->setDate($now);
         $order->setPaymentMethodName($pmName);
         $order->setShippingMethodName($smName);
+        $order->setShippingInstructions($sInstructions);
         $order->setShippingTotal($shippingTotal);
         $order->setTaxTotal($taxes['taxTotals']);
         $order->setTaxIncluded($taxes['taxIncludedTotals']);
@@ -425,7 +441,7 @@ class Order
 
         $fromName = Config::get('community_store.emailalertsname');
 
-        $smID = \Session::get('smID');
+        $smID = \Session::get('community_store.smID');
         $groupstoadd = array();
         $createlogin = false;
         $orderItems = $this->getOrderItems();
@@ -537,7 +553,7 @@ class Order
             $customer->setValue('billing_address', $billing_address);
             $customer->setValue('billing_phone', $billing_phone);
 
-            if ($smID) {
+            if ($order->isShippable()) {
                 $customer->setValue('shipping_first_name', $shipping_first_name);
                 $customer->setValue('shipping_last_name', $shipping_last_name);
                 $customer->setValue('shipping_address', $shipping_address);
@@ -614,7 +630,7 @@ class Order
         }
 
         // unset the shipping type, as next order might be unshippable
-        \Session::set('smID', '');
+        \Session::set('community_store.smID', '');
 
         StoreCart::clear();
 

--- a/src/CommunityStore/Shipping/Method/ShippingMethod.php
+++ b/src/CommunityStore/Shipping/Method/ShippingMethod.php
@@ -228,7 +228,7 @@ class ShippingMethod
 
     public static function getActiveShippingMethod()
     {
-        $smID = \Session::get('smID');
+        $smID = \Session::get('community_store.smID');
         if ($smID) {
             $sm = self::getByID($smID);
 

--- a/src/CommunityStore/Utilities/Calculator.php
+++ b/src/CommunityStore/Utilities/Calculator.php
@@ -34,10 +34,10 @@ class Calculator
             return false;
         }
 
-        $existingShippingMethodID = Session::get('smID');
+        $existingShippingMethodID = Session::get('community_store.smID');
         if ($smID) {
             $shippingMethod = StoreShippingMethod::getByID($smID);
-            Session::set('smID', $smID);
+            Session::set('community_store.smID', $smID);
         } elseif ($existingShippingMethodID) {
             $shippingMethod = StoreShippingMethod::getByID($existingShippingMethodID);
         }


### PR DESCRIPTION
This adds in an optional 'delivery instructions' field within the shipping selection in the checkout.
Although this could potentially be handled by an order attribute, I think this field is so commonly used/expected, and specific in purpose that it makes sense to include it as a core field - it then shows on order emails and screens next to the shipping method.

(fix other fixes as well)