### PR TITLE
Option to include addition payment information in receipt emails

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -15,7 +15,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '5.7.5';
-    protected $pkgVersion = '0.9.8';
+    protected $pkgVersion = '0.9.8.1';
 
     public function getPackageDescription()
     {

--- a/elements/invoice/dashboard_form.php
+++ b/elements/invoice/dashboard_form.php
@@ -13,3 +13,10 @@ extract($vars);
     <input type="text" name="invoiceMaximum" value="<?= $invoiceMaximum?>" class="form-control">
 </div>
 
+<div class="form-group">
+    <label><?= t("Payment Instructions")?></label>
+    <?php $editor = \Core::make('editor');
+    echo $editor->outputStandardEditor('paymentInstructions', $paymentInstructions);?>
+</div>
+
+

--- a/mail/order_receipt.php
+++ b/mail/order_receipt.php
@@ -166,6 +166,9 @@ if (count($downloads) > 0) {
     <strong class="text-large"><?= t("Total") ?>:</strong> <?= StorePrice::format($order->getTotal()) ?><br><br>
     <strong><?= t("Payment Method") ?>: </strong><?= $order->getPaymentMethodName() ?>
 </p>
+
+<?php echo $paymentInstructions; ?>
+
 </body>
 </html>
 
@@ -223,6 +226,10 @@ if (!empty($applieddiscounts)) { ?>
     ?>
 <?php } ?>
 <?= t("Total") ?>: <?= StorePrice::format($order->getTotal()) ?>
+
+<?= t("Payment Method") ?>: </strong><?= $order->getPaymentMethodName() ?>
+
+<?php echo strip_tags($paymentInstructions); ?>
 
 <?php
 

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -45,6 +45,9 @@ class Order
     /** @Column(type="datetime") */
     protected $oDate;
 
+    /** @Column(type="integer",nullable=true) */
+    protected $pmID;
+
     /** @Column(type="text") */
     protected $pmName;
 
@@ -103,6 +106,11 @@ class Order
     public function setPaymentMethodName($pmName)
     {
         $this->pmName = $pmName;
+    }
+
+    public function setPaymentMethodID($pmID)
+    {
+        $this->pmID = $pmID;
     }
 
     public function setShippingMethodName($smName)
@@ -164,6 +172,11 @@ class Order
     public function getOrderDate()
     {
         return $this->oDate;
+    }
+
+    public function getPaymentMethodID()
+    {
+        return $this->pmID;
     }
 
     public function getPaymentMethodName()
@@ -306,6 +319,7 @@ class Order
         $order->setCustomerID($customer->getUserID());
         $order->setDate($now);
         $order->setPaymentMethodName($pmName);
+        $order->setPaymentMethodID($pm->getID());
         $order->setShippingMethodName($smName);
         $order->setShippingInstructions($sInstructions);
         $order->setShippingTotal($shippingTotal);
@@ -553,7 +567,7 @@ class Order
             $customer->setValue('billing_address', $billing_address);
             $customer->setValue('billing_phone', $billing_phone);
 
-            if ($order->isShippable()) {
+            if ($this->isShippable()) {
                 $customer->setValue('shipping_first_name', $shipping_first_name);
                 $customer->setValue('shipping_last_name', $shipping_last_name);
                 $customer->setValue('shipping_address', $shipping_address);
@@ -603,6 +617,17 @@ class Order
 
         $mh->to($customer->getEmail());
 
+        $pmID = $this->getPaymentMethodID();
+
+        $paymentInstructions = '';
+        if ($pmID) {
+            $paymentMethodUsed = StorePaymentMethod::getByID($this->getPaymentMethodID());
+            if ($paymentMethodUsed) {
+                $paymentInstructions = $paymentMethodUsed->getMethodController()->getPaymentInstructions();
+            }
+        }
+
+        $mh->addParameter('paymentInstructions', $paymentInstructions);
         $mh->addParameter("order", $this);
         $mh->load("order_receipt", "community_store");
         $mh->sendMail();

--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -289,4 +289,9 @@ class Method extends Controller
     // method stub
     public function checkoutForm() {
     }
+
+    // method stub
+    public function getPaymentInstructions() {
+        return '';
+    }
 }

--- a/src/CommunityStore/Payment/Methods/Invoice/InvoicePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/Invoice/InvoicePaymentMethod.php
@@ -16,13 +16,15 @@ class InvoicePaymentMethod extends StorePaymentMethod
     {
         $this->set('form', Core::make("helper/form"));
         $this->set('invoiceMinimum', Config::get('community_store.invoiceMinimum'));
-        $this->set('invoiceMaximum', Config::get('community_store.invoiceMaximum'));
+        $this->set('invoiceMinimum', Config::get('community_store.invoiceMinimum'));
+        $this->set('paymentInstructions', Config::get('community_store.paymentInstructions'));
     }
 
     public function save(array $data = [])
     {
         Config::save('community_store.invoiceMinimum', $data['invoiceMinimum']);
         Config::save('community_store.invoiceMaximum', $data['invoiceMaximum']);
+        Config::save('community_store.paymentInstructions', $data['paymentInstructions']);
     }
     public function validate($args, $e)
     {
@@ -76,5 +78,11 @@ class InvoicePaymentMethod extends StorePaymentMethod
         } else {
             return min($maxconfig, $defaultMax);
         }
+    }
+
+    // to be overridden by individual payment methods
+    public function getPaymentInstructions()
+    {
+        return Config::get('community_store.paymentInstructions');
     }
 }


### PR DESCRIPTION
This allows a payment method to have an HTML field to output additional payment details. 
For payment methods like EFT or cheques, this is to provide bank details or instructions.

This has been added to the built-in Invoice method.