### PR TITLE
Payment statuses

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -15,7 +15,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '5.7.5';
-    protected $pkgVersion = '0.9.8';
+    protected $pkgVersion = '0.9.8.2';
 
     public function getPackageDescription()
     {

--- a/controllers/single_page/dashboard/store/orders.php
+++ b/controllers/single_page/dashboard/store/orders.php
@@ -65,6 +65,74 @@ class Orders extends DashboardPageController
         StoreOrder::getByID($oID)->updateStatus($data['orderStatus']);
         $this->redirect('/dashboard/store/orders/order',$oID);
     }
+
+    public function markpaid($oID)
+    {
+        $order = StoreOrder::getByID($oID);
+
+        if ($this->post('transactionReference')) {
+            $order->setTransactionReference($this->post('transactionReference'));
+        }
+
+        $user = new \User();
+
+        $order->setPaid(new \DateTime());
+        $order->setPaidByUID($user->getUserID());
+        $order->save();
+
+        $this->redirect('/dashboard/store/orders/order',$oID);
+    }
+
+    public function reversepaid($oID)
+    {
+        $order = StoreOrder::getByID($oID);
+        $order->setPaid(null);
+        $order->setPaidByUID(null);
+        $order->setTransactionReference(null);
+        $order->save();
+
+        $this->redirect('/dashboard/store/orders/order',$oID);
+    }
+
+
+
+
+    public function markrefunded($oID)
+    {
+        $order = StoreOrder::getByID($oID);
+        $user = new \User();
+
+        $order->setRefunded(new \DateTime());
+        $order->setRefundedByUID($user->getUserID());
+        $order->setRefundReason($this->post('oRefundReason'));
+        $order->save();
+
+        $this->redirect('/dashboard/store/orders/order',$oID);
+    }
+
+    public function reverserefund($oID)
+    {
+        $order = StoreOrder::getByID($oID);
+        $order->setRefunded(null);
+        $order->setRefundedByUID(null);
+        $order->setRefundReason(null);
+        $order->save();
+
+        $this->redirect('/dashboard/store/orders/order',$oID);
+    }
+
+    public function markcancelled($oID)
+    {
+        $order = StoreOrder::getByID($oID);
+        $user = new \User();
+
+        $order->setCancelled(new \DateTime());
+        $order->setCancelledByUID($user->getUserID());
+        $order->save();
+
+        $this->redirect('/dashboard/store/orders/order',$oID);
+    }
+
     public function remove($oID)
     {
         StoreOrder::getByID($oID)->remove();

--- a/controllers/single_page/dashboard/store/orders.php
+++ b/controllers/single_page/dashboard/store/orders.php
@@ -133,6 +133,18 @@ class Orders extends DashboardPageController
         $this->redirect('/dashboard/store/orders/order',$oID);
     }
 
+
+
+    public function reversecancel($oID)
+    {
+        $order = StoreOrder::getByID($oID);
+        $order->setCancelled(null);
+        $order->setCancelledByUID(null);
+        $order->save();
+
+        $this->redirect('/dashboard/store/orders/order',$oID);
+    }
+
     public function remove($oID)
     {
         StoreOrder::getByID($oID)->remove();

--- a/elements/invoice/dashboard_form.php
+++ b/elements/invoice/dashboard_form.php
@@ -13,3 +13,10 @@ extract($vars);
     <input type="text" name="invoiceMaximum" value="<?= $invoiceMaximum?>" class="form-control">
 </div>
 
+<div class="form-group">
+    <label><?= t("Payment Instructions")?></label>
+    <?php $editor = \Core::make('editor');
+    echo $editor->outputStandardEditor('paymentInstructions', $paymentInstructions);?>
+</div>
+
+

--- a/js/communityStoreFunctions.js
+++ b/js/communityStoreFunctions.js
@@ -71,6 +71,15 @@ $(function(){
             window.location = url;
         }
     });
+
+    $(".confirm-action").click(function(e){
+        e.preventDefault();
+        var confirmDelete = confirm($(this).data('confirm-message'));
+        if(confirmDelete == true) {
+            $(this).closest('form').submit();
+        }
+    });
+
     $("#btn-generate-page").click(function(e){
         e.preventDefault();
         var url = $(this).attr("href");

--- a/mail/order_receipt.php
+++ b/mail/order_receipt.php
@@ -166,6 +166,9 @@ if (count($downloads) > 0) {
     <strong class="text-large"><?= t("Total") ?>:</strong> <?= StorePrice::format($order->getTotal()) ?><br><br>
     <strong><?= t("Payment Method") ?>: </strong><?= $order->getPaymentMethodName() ?>
 </p>
+
+<?php echo $paymentInstructions; ?>
+
 </body>
 </html>
 
@@ -223,6 +226,10 @@ if (!empty($applieddiscounts)) { ?>
     ?>
 <?php } ?>
 <?= t("Total") ?>: <?= StorePrice::format($order->getTotal()) ?>
+
+<?= t("Payment Method") ?>: </strong><?= $order->getPaymentMethodName() ?>
+
+<?php echo strip_tags($paymentInstructions); ?>
 
 <?php
 

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -14,10 +14,11 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
         </form>
     </div>
 
-    <h3><?= t("Customer Overview")?></h3>
-    <hr>
+    <fieldset>
+    <legend><?= t("Customer Overview")?></legend>
+
     <div class="row">
-        <div class="col-sm-12">
+        <div class="col-sm-4">
             <?php $orderemail = $order->getAttribute("email");
 
             if ($orderemail) { ?>
@@ -33,7 +34,7 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
             <?php } ?>
         </div>
 
-        <div class="col-sm-6">
+        <div class="col-sm-4">
             <h4><?= t("Billing Information")?></h4>
             <p>
                 <?= $order->getAttribute("billing_first_name"). " " . $order->getAttribute("billing_last_name")?><br>
@@ -46,7 +47,7 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
             </p>
         </div>
         <?php if ($order->isShippable()) { ?>
-            <div class="col-sm-6">
+            <div class="col-sm-4">
                 <?php if ($order->getAttribute("shipping_address")->address1) { ?>
                     <h4><?= t("Shipping Information")?></h4>
                     <p>
@@ -61,8 +62,13 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
             </div>
         <?php } ?>
     </div>
-    <h3><?= t("Order Info")?></h3>
-    <hr>
+    </fieldset>
+
+    <fieldset>
+    <legend><?= t("Order Info")?></legend>
+
+    <p><strong><?= t('Order placed'); ?>:</strong> <?= $dh->formatDateTime($order->getOrderDate())?></p>
+
     <table class="table table-striped">
         <thead>
             <tr>
@@ -195,33 +201,17 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
 
     <?php } ?>
 
-
+    </fieldset>
     <br />
-    <h3><?= t("Order Status History")?></h3>
-    <hr>
+
     <div class="row">
-        <div class="col-sm-4">
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h4 class="panel-title"><?= t("Update Status")?></h4>
-                </div>
-                <div class="panel-body">
-
-                    <form action="<?=URL::to("/dashboard/store/orders/updatestatus",$order->getOrderID())?>" method="post">
-                        <div class="form-group">
-                            <?= $form->select("orderStatus",$orderStatuses,$order->getStatus());?>
-                        </div>
-                        <input type="submit" class="btn btn-default" value="<?= t("Update")?>">
-                    </form>
-
-                </div>
-            </div>
-        </div>
-        <div class="col-sm-8">
+        <div class="col-sm-6">
+            <fieldset>
+            <legend><?= t("Fulfilment")?></legend>
             <table class="table table-striped">
                 <thead>
                 <tr>
-                    <th><strong><?= t("Status")?></strong></th>
+                    <th><?= t("Status")?></th>
                     <th><?= t("Date")?></th>
                     <th><?= t("User")?></th>
                 </tr>
@@ -237,17 +227,151 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
                             <td><?= $status->getDate()?></td>
                             <td><?= $status->getUserName()?></td>
                         </tr>
-                    <?php
+                        <?php
                     }
                 }
                 ?>
                 </tbody>
             </table>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4 class="panel-title"><?= t("Update Fulfilment Status")?></h4>
+                </div>
+                <div class="panel-body">
+
+                    <form action="<?=URL::to("/dashboard/store/orders/updatestatus",$order->getOrderID())?>" method="post">
+                        <div class="form-group">
+                            <?= $form->select("orderStatus",$orderStatuses,$order->getStatus());?>
+                        </div>
+                        <input type="submit" class="btn btn-default" value="<?= t("Update")?>">
+                    </form>
+
+                </div>
+            </div>
+            </fieldset>
+        </div>
+        <div class="col-sm-6">
+            <fieldset>
+            <legend><?= t("Payment Status")?></legend>
+
+
+
+            <?php  if($order->getTotal() == 0) { ?>
+            <p><?= t('Free Order');?></p>
+            <?php } else {
+
+             $paid = $order->getPaid();
+             $refunded = $order->getRefunded();
+
+            if (!$paid) { ?>
+            <p class="alert alert-danger"><?= t('Unpaid');?></p>
+            <?php } ?>
+
+            <?php if ($paid || $refunded) { ?>
+            <table class="table table-striped">
+                <thead>
+                <tr>
+                    <th><?= t("Status")?></th>
+                    <th><?= t("Date / Reference")?></th>
+                    <th><?= t("By")?></th>
+                    <th></th>
+                </tr>
+                </thead>
+                <tbody>
+
+                <?php if ($paid) { ?>
+                    <tr>
+                        <td><?= t('Paid')?>
+                        </td>
+                        <td><?= $dh->formatDateTime($paid)?>
+                            <br />
+                            <?= t('Ref') . ':'?> <?= $order->getTransactionReference() ; ?>
+                        </td>
+                        <td>
+                        <?php $paiduser = User::getByUserID($order->getPaidByUID());
+                            if ($paiduser) {
+                                echo $paiduser->getUserName();
+                            } else {
+                                echo t('payment');
+                            }
+                        ?></td>
+                        <td><?php if (!$refunded && $paiduser) { ?>
+
+                         <form action="<?=URL::to("/dashboard/store/orders/reversepaid",$order->getOrderID())?>" method="post">
+                            <input data-confirm-message="<?= h(t('Are you sure you wish to reverse this payment?')); ?>" type="submit" class="confirm-action btn-link" value="<?= t("reverse")?>">
+                         </form>
+
+                        <?php } ?></td>
+
+                    </tr>
+                 <?php } ?>
+
+                 <?php if ($refunded) { ?>
+                    <tr>
+                        <td><?= t('Refunded')?></td>
+                        <td><?= $dh->formatDateTime($refunded)?><br />
+                        <?= $order->getRefundReason(); ?>
+                        </td>
+                        <td>
+                        <?php $refundeduser = User::getByUserID($order->getRefundedByUID());
+                            if ($refundeduser) {
+                                echo $refundeduser->getUserName();
+                            }
+                        ?></td>
+                        <td>
+
+                         <form action="<?=URL::to("/dashboard/store/orders/reverserefund",$order->getOrderID())?>" method="post">
+                            <input data-confirm-message="<?= h(t('Are you sure you wish to reverse this refund?')); ?>" type="submit" class="confirm-action btn-link" value="<?= t("reverse")?>">
+                         </form>
+
+                        </td>
+
+                    </tr>
+                 <?php } ?>
+
+                </tbody>
+            </table>
+             <?php } ?>
+
+           <?php if (!$paid || !$refunded) { ?>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4 class="panel-title"><?= t("Update Payment Status")?></h4>
+                </div>
+                <div class="panel-body">
+
+                    <?php if (!$paid) { ?>
+                    <form action="<?=URL::to("/dashboard/store/orders/markpaid",$order->getOrderID())?>" method="post">
+                       <div class="form-group">
+                       <label for="transactionReference"><?= t('Transaction Reference'); ?></label>
+                       <input type="text" class="form-control ccm-input-text" name="transactionReference" />
+                       </div>
+                        <input type="submit" class="btn btn-default" value="<?= t("Mark Paid")?>">
+                    </form>
+                    <?php } elseif (!$refunded) {  ?>
+                        <form action="<?=URL::to("/dashboard/store/orders/markrefunded",$order->getOrderID())?>" method="post">
+                           <div class="form-group">
+                           <label for="oRefundReason"><?= t('Refund Reason'); ?></label>
+                           <input type="text" class="form-control ccm-input-text" name="oRefundReason" />
+                           </div>
+                            <input type="submit" class="btn btn-default" value="<?= t("Mark Refunded")?>">
+                        </form>
+                    <?php } ?>
+
+                </div>
+            </div>
+            <?php } ?>
+
+             <?php } ?>
+
+             </fieldset>
         </div>
 
     </div>
+    </fieldset>
 
-    <h3><?= t("Manage Order")?></h3>
+    <fieldset>
+    <legend><?= t("Cancel Order")?></legend>
     <hr>
     <div class="row">
         <div class="col-sm-4">
@@ -263,6 +387,7 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
             </div>
         </div>
     </div>
+    </fieldset>
 
 
 <?php } else { ?>
@@ -307,7 +432,8 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
             <th><a><?= t("Customer Name")?></a></th>
             <th><a><?= t("Order Date")?></a></th>
             <th><a><?= t("Total")?></a></th>
-            <th><a><?= t("Status")?></a></th>
+            <th><a><?= t("Payment")?></a></th>
+            <th><a><?= t("Fulfilment")?></a></th>
             <th><a><?= t("View")?></a></th>
         </thead>
         <tbody>
@@ -318,7 +444,26 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
                     <td><a href="<?=URL::to('/dashboard/store/orders/order/',$order->getOrderID())?>"><?= $order->getOrderID()?></a></td>
                     <td><?= $order->getAttribute('billing_last_name').", ".$order->getAttribute('billing_first_name')?></td>
                     <td><?= $dh->formatDateTime($order->getOrderDate())?></td>
-                <td><?=Price::format($order->getTotal())?></td>
+                    <td><?=Price::format($order->getTotal())?></td>
+                    <td>
+                        <?php
+                        $refunded = $order->getRefunded();
+                        $paid = $order->getPaid();
+
+                        if ($refunded) {
+                            echo '<span class="label label-warning">' . t('refunded') . '</span>';
+                        } elseif ($paid) {
+                            echo '<span class="label label-success">' . t('paid') . '</span>';
+                        } elseif ($order->getTotal() > 0) {
+                            echo '<span class="label label-danger">' . t('unpaid') . '</span>';
+                        } else {
+                            echo '<span class="label label-default">' . t('free order') . '</span>';
+                        }
+
+
+                        ?>
+
+                    </td>
                     <td><?=t(ucwords($order->getStatus()))?></td>
                     <td><a class="btn btn-primary" href="<?=URL::to('/dashboard/store/orders/order/',$order->getOrderID())?>"><?= t("View")?></a></td>
                 </tr>

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -8,11 +8,36 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
 <?php if ($controller->getTask() == 'order'){ ?>
 
     <div class="ccm-dashboard-header-buttons">
+
         <form action="<?=URL::to('/dashboard/store/orders/details/slip')?>" method="post" target="_blank">
             <input type="hidden" name="oID" value="<?= $order->getOrderID()?>">
             <button class="btn btn-primary"><?= t("Print Order Slip")?></button>
         </form>
     </div>
+
+
+
+<div class="row">
+    <div class="col-sm-8">
+        <p><strong><?= t('Order placed'); ?>:</strong> <?= $dh->formatDateTime($order->getOrderDate())?></p>
+     </div>
+    <div class="col-sm-4">
+    <?php
+    $refunded = $order->getRefunded();
+    $paid = $order->getPaid();
+
+    if ($refunded) {
+        echo '<p class="alert alert-warning text-center"><strong>' . t('Refunded') . ' - '. $order->getRefundReason(). '</strong></p>';
+    } elseif ($paid) {
+        echo '<p class="alert alert-success text-center"><strong>' . t('Paid') . '</strong></p>';
+    } elseif ($order->getTotal() > 0) {
+        echo '<p class="alert alert-danger text-center"><strong>' . t('Unpaid') . '</strong></p>';
+    } else {
+        echo '<p class="alert alert-default text-center"><strong>' . t('Free Order') . '</strong></p>';
+    }
+    ?>
+    </div>
+</div>
 
     <fieldset>
     <legend><?= t("Customer Overview")?></legend>
@@ -65,9 +90,7 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
     </fieldset>
 
     <fieldset>
-    <legend><?= t("Order Info")?></legend>
-
-    <p><strong><?= t('Order placed'); ?>:</strong> <?= $dh->formatDateTime($order->getOrderDate())?></p>
+    <legend><?= t("Order Items")?></legend>
 
     <table class="table table-striped">
         <thead>
@@ -259,12 +282,8 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
             <?php  if($order->getTotal() == 0) { ?>
             <p><?= t('Free Order');?></p>
             <?php } else {
-
-             $paid = $order->getPaid();
-             $refunded = $order->getRefunded();
-
             if (!$paid) { ?>
-            <p class="alert alert-danger"><?= t('Unpaid');?></p>
+            <p class="text-danger"><?= t('Unpaid');?></p>
             <?php } ?>
 
             <?php if ($paid || $refunded) { ?>
@@ -451,18 +470,15 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
                         $paid = $order->getPaid();
 
                         if ($refunded) {
-                            echo '<span class="label label-warning">' . t('refunded') . '</span>';
+                            echo '<span class="label label-warning">' . t('Refunded') . '</span>';
                         } elseif ($paid) {
-                            echo '<span class="label label-success">' . t('paid') . '</span>';
+                            echo '<span class="label label-success">' . t('Paid') . '</span>';
                         } elseif ($order->getTotal() > 0) {
-                            echo '<span class="label label-danger">' . t('unpaid') . '</span>';
+                            echo '<span class="label label-danger">' . t('Unpaid') . '</span>';
                         } else {
-                            echo '<span class="label label-default">' . t('free order') . '</span>';
+                            echo '<span class="label label-default">' . t('Free Order') . '</span>';
                         }
-
-
                         ?>
-
                     </td>
                     <td><?=t(ucwords($order->getStatus()))?></td>
                     <td><a class="btn btn-primary" href="<?=URL::to('/dashboard/store/orders/order/',$order->getOrderID())?>"><?= t("View")?></a></td>

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -73,8 +73,12 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
                 if ($billingaddress) {
                     echo $billingaddress->getValue('displaySanitized', 'display');
                 }
+
+                $phone = $order->getAttribute("billing_phone");
+                if ($phone) {
                 ?>
-                <br /> <br /><?= t('Phone'); ?>: <?= $order->getAttribute("billing_phone")?>
+                <br /> <br /><?= t('Phone'); ?>: <?= $phone; ?>
+                <?php } ?>
             </p>
         </div>
         <?php if ($order->isShippable()) { ?>
@@ -395,14 +399,22 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
     </div>
     </fieldset>
 
-    <fieldset>
+
 
      <?php if (!$order->getCancelled()) { ?>
-     <legend><?= t("Cancel Order")?></legend>
-        <form action="<?=URL::to("/dashboard/store/orders/markcancelled",$order->getOrderID())?>" method="post">
-        <input data-confirm-message="<?= h(t('Are you sure you wish to cancel this order?')); ?>" type="submit" class="confirm-action btn btn-danger" value="<?= t("Cancel Order")?>">
-        </form>
+        <fieldset>
+            <legend><?= t("Cancel Order")?></legend>
+            <form action="<?=URL::to("/dashboard/store/orders/markcancelled",$order->getOrderID())?>" method="post">
+            <input data-confirm-message="<?= h(t('Are you sure you wish to cancel this order?')); ?>" type="submit" class="confirm-action btn btn-danger" value="<?= t("Cancel Order")?>">
+            </form>
+        </fieldset>
     <?php } else { ?>
+     <form action="<?=URL::to("/dashboard/store/orders/reversecancel",$order->getOrderID())?>" method="post">
+        <input data-confirm-message="<?= h(t('Are you sure you wish to reverse this cancellation?')); ?>" type="submit" class="confirm-action btn btn-default" value="<?= t("Reverse Cancellation")?>">
+     </form>
+     <br />
+
+    <fieldset>
     <legend><?= t("Delete Order")?></legend>
         <a data-confirm-message="<?= h(t('Are you sure you wish to completely delete this order? The order number will be reused.')); ?>" id="btn-delete-order" href="<?=URL::to("/dashboard/store/orders/remove", $order->getOrderID())?>" class="btn btn-danger"><?= t("Delete Order")?></a>
     <?php } ?>
@@ -476,7 +488,18 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
                     }
                     ?>
                     </td>
-                    <td><?= $canstart; ?><?= $order->getAttribute('billing_last_name').", ".$order->getAttribute('billing_first_name')?><?= $canend; ?></td>
+                    <td><?= $canstart; ?><?php
+
+                   $last = $order->getAttribute('billing_last_name');
+                   $first = $order->getAttribute('billing_first_name');
+
+                   if ($last || $first ) {
+                    echo $last.", ".$first;
+                   } else {
+                    echo '<em>' .t('Not found') . '</em>';
+                   }
+
+                    ?><?= $canend; ?></td>
                     <td><?= $canstart; ?><?= $dh->formatDateTime($order->getOrderDate())?><?= $canend; ?></td>
                     <td><?= $canstart; ?><?=Price::format($order->getTotal())?><?= $canend; ?></td>
                     <td>

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -489,51 +489,23 @@ class Order
         }
     }
 
-    public function addOrderItems($cart)
-    {
-        $taxCalc = Config::get('community_store.calculation');
-        foreach ($cart as $cartItem) {
-            $taxes = StoreTax::getTaxForProduct($cartItem);
-            $taxProductTotal = array();
-            $taxProductIncludedTotal = array();
-            $taxProductLabels = array();
-
-            foreach ($taxes as $tax) {
-                if ($taxCalc == 'extract') {
-                    $taxProductIncludedTotal[] = $tax['taxamount'];
-                } else {
-                    $taxProductTotal[] = $tax['taxamount'];
-                }
-                $taxProductLabels[] = $tax['name'];
-            }
-            $taxProductTotal = implode(',', $taxProductTotal);
-            $taxProductIncludedTotal = implode(',', $taxProductIncludedTotal);
-            $taxProductLabels = implode(',', $taxProductLabels);
-
-            $orderItem = StoreOrderItem::add($cartItem, $this->getOrderID(), $taxProductTotal, $taxProductIncludedTotal, $taxProductLabels);
-            $this->orderItems->add($orderItem);
-        }
-    }
-
-    public function save()
-    {
-        $em = \Database::connection()->getEntityManager();
-        $em->persist($this);
-        $em->flush();
-    }
-
-    public function delete()
-    {
-        $this->getShippingMethodTypeMethod()->delete();
-        $em = \Database::connection()->getEntityManager();
-        $em->remove($this);
-        $em->flush();
-    }
-
     public function completeOrder($transactionReference = null)
     {
         if ($transactionReference) {
             $this->setTransactionReference($transactionReference);
+        }
+
+        $pmID = $this->getPaymentMethodID();
+
+        if ($pmID) {
+            $paymentMethodUsed = StorePaymentMethod::getByID($this->getPaymentMethodID());
+
+            if ($paymentMethodUsed) {
+                // if the payment method actually is a payment (as opposed to an invoice), mark order as paid
+                if ($paymentMethodUsed->getMethodController()->markPaid()) {
+                    $this->setPaid(new \DateTime());
+                }
+            }
         }
 
         $this->setExternalPaymentRequested(null);
@@ -590,8 +562,6 @@ class Order
                 }
 
                 $valc = Core::make('helper/concrete/validation');
-
-
                 $min = Config::get('concrete.user.username.minimum');
                 $max = Config::get('concrete.user.username.maximum');
 
@@ -708,14 +678,9 @@ class Order
 
         $mh->to($customer->getEmail());
 
-        $pmID = $this->getPaymentMethodID();
-
         $paymentInstructions = '';
-        if ($pmID) {
-            $paymentMethodUsed = StorePaymentMethod::getByID($this->getPaymentMethodID());
-            if ($paymentMethodUsed) {
-                $paymentInstructions = $paymentMethodUsed->getMethodController()->getPaymentInstructions();
-            }
+        if ($paymentMethodUsed) {
+            $paymentInstructions = $paymentMethodUsed->getMethodController()->getPaymentInstructions();
         }
 
         $mh->addParameter('paymentInstructions', $paymentInstructions);
@@ -751,6 +716,47 @@ class Order
         StoreCart::clear();
 
         return $this;
+    }
+
+    public function addOrderItems($cart)
+    {
+        $taxCalc = Config::get('community_store.calculation');
+        foreach ($cart as $cartItem) {
+            $taxes = StoreTax::getTaxForProduct($cartItem);
+            $taxProductTotal = array();
+            $taxProductIncludedTotal = array();
+            $taxProductLabels = array();
+
+            foreach ($taxes as $tax) {
+                if ($taxCalc == 'extract') {
+                    $taxProductIncludedTotal[] = $tax['taxamount'];
+                } else {
+                    $taxProductTotal[] = $tax['taxamount'];
+                }
+                $taxProductLabels[] = $tax['name'];
+            }
+            $taxProductTotal = implode(',', $taxProductTotal);
+            $taxProductIncludedTotal = implode(',', $taxProductIncludedTotal);
+            $taxProductLabels = implode(',', $taxProductLabels);
+
+            $orderItem = StoreOrderItem::add($cartItem, $this->getOrderID(), $taxProductTotal, $taxProductIncludedTotal, $taxProductLabels);
+            $this->orderItems->add($orderItem);
+        }
+    }
+
+    public function save()
+    {
+        $em = \Database::connection()->getEntityManager();
+        $em->persist($this);
+        $em->flush();
+    }
+
+    public function delete()
+    {
+        $this->getShippingMethodTypeMethod()->delete();
+        $em = \Database::connection()->getEntityManager();
+        $em->remove($this);
+        $em->flush();
     }
 
     public function remove()

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -73,6 +73,27 @@ class Order
     protected $transactionReference;
 
     /** @Column(type="datetime", nullable=true) */
+    protected $oPaid;
+
+    /** @Column(type="integer", nullable=true) */
+    protected $oPaidByUID;
+
+    /** @Column(type="datetime", nullable=true) */
+    protected $oCancelled;
+
+    /** @Column(type="integer", nullable=true) */
+    protected $oCancelledByUID;
+
+    /** @Column(type="datetime", nullable=true) */
+    protected $oRefunded;
+
+    /** @Column(type="integer", nullable=true) */
+    protected $oRefundedByUID;
+
+    /** @Column(type="text",nullable=true) */
+    protected $oRefundReason;
+
+    /** @Column(type="datetime", nullable=true) */
     protected $externalPaymentRequested;
 
     /**
@@ -149,6 +170,76 @@ class Order
     {
         $this->setTransactionReference($transactionReference);
         $this->save();
+    }
+
+    public function getPaid()
+    {
+        return $this->oPaid;
+    }
+
+    public function setPaid($oPaid)
+    {
+        $this->oPaid = $oPaid;
+    }
+
+    public function getPaidByUID()
+    {
+        return $this->oPaidByUID;
+    }
+
+    public function setPaidByUID($oPaidByUID)
+    {
+        $this->oPaidByUID = $oPaidByUID;
+    }
+
+    public function getCancelled()
+    {
+        return $this->oCancelled;
+    }
+
+    public function setCancelled($oCancelled)
+    {
+        $this->oCancelled = $oCancelled;
+    }
+
+    public function getCancelledByUID()
+    {
+        return $this->oCancelledByUID;
+    }
+
+    public function setCancelledByUID($oCancelledByUID)
+    {
+        $this->oCancelledByUID = $oCancelledByUID;
+    }
+
+    public function getRefunded()
+    {
+        return $this->oRefunded;
+    }
+
+    public function setRefunded($oRefunded)
+    {
+        $this->oRefunded = $oRefunded;
+    }
+
+    public function getRefundedByUID()
+    {
+        return $this->oRefundedByUID;
+    }
+
+    public function setRefundedByUID($oRefundedByUID)
+    {
+        $this->oRefundedByUID = $oRefundedByUID;
+    }
+
+    public function getRefundReason()
+    {
+        return $this->oRefundReason;
+    }
+
+    public function setRefundReason($oRefundReason)
+    {
+        $this->oRefundReason = $oRefundReason;
     }
 
     public function getOrderID()

--- a/src/CommunityStore/Order/OrderList.php
+++ b/src/CommunityStore/Order/OrderList.php
@@ -60,6 +60,11 @@ class OrderList  extends AttributedItemList
         if (isset($this->toDate)) {
             $this->query->andWhere('DATE(oDate) <= DATE(?)')->setParameter($paramcount++, $this->toDate);
         }
+        if (isset($this->paid)) {
+            $this->query->andWhere('o.oPaid is not null');
+            $this->query->andWhere('o.oRefunded is null');
+        }
+
         if ($this->limit > 0) {
             $this->query->setMaxResults($this->limit);
         }
@@ -106,6 +111,11 @@ class OrderList  extends AttributedItemList
     public function setLimit($limit = 0)
     {
         $this->limit = $limit;
+    }
+
+    public function setPaid($bool)
+    {
+        $this->paid = $bool;
     }
 
     public function getResult($queryRow)

--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -282,6 +282,10 @@ class Method extends Controller
         return false;
     }
 
+    public function markPaid() {
+        return true;
+    }
+
     // method stub
     public function redirectForm() {
     }

--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -293,4 +293,9 @@ class Method extends Controller
     // method stub
     public function checkoutForm() {
     }
+
+    // method stub
+    public function getPaymentInstructions() {
+        return '';
+    }
 }

--- a/src/CommunityStore/Payment/Methods/Invoice/InvoicePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/Invoice/InvoicePaymentMethod.php
@@ -16,13 +16,15 @@ class InvoicePaymentMethod extends StorePaymentMethod
     {
         $this->set('form', Core::make("helper/form"));
         $this->set('invoiceMinimum', Config::get('community_store.invoiceMinimum'));
-        $this->set('invoiceMaximum', Config::get('community_store.invoiceMaximum'));
+        $this->set('invoiceMinimum', Config::get('community_store.invoiceMinimum'));
+        $this->set('paymentInstructions', Config::get('community_store.paymentInstructions'));
     }
 
     public function save(array $data = [])
     {
         Config::save('community_store.invoiceMinimum', $data['invoiceMinimum']);
         Config::save('community_store.invoiceMaximum', $data['invoiceMaximum']);
+        Config::save('community_store.paymentInstructions', $data['paymentInstructions']);
     }
     public function validate($args, $e)
     {
@@ -80,5 +82,11 @@ class InvoicePaymentMethod extends StorePaymentMethod
 
     public function markPaid() {
         return false;
+    }
+
+    // to be overridden by individual payment methods
+    public function getPaymentInstructions()
+    {
+        return Config::get('community_store.paymentInstructions');
     }
 }

--- a/src/CommunityStore/Payment/Methods/Invoice/InvoicePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/Invoice/InvoicePaymentMethod.php
@@ -77,4 +77,8 @@ class InvoicePaymentMethod extends StorePaymentMethod
             return min($maxconfig, $defaultMax);
         }
     }
+
+    public function markPaid() {
+        return false;
+    }
 }

--- a/src/CommunityStore/Report/ProductReport.php
+++ b/src/CommunityStore/Report/ProductReport.php
@@ -29,6 +29,7 @@ class ProductReport extends AbstractItemList
         $orders = new StoreOrderList();
         $orders->setFromDate($from);
         $orders->setToDate($to);
+        $orders->setPaid(true);
         $this->orderItems = $orders->getOrderItems();
     }
 

--- a/src/CommunityStore/Report/SalesReport.php
+++ b/src/CommunityStore/Report/SalesReport.php
@@ -11,6 +11,7 @@ class SalesReport extends StoreOrderList
         $this->setFromDate();
         $this->setToDate();
         $this->setLimit(0);
+        $this->setPaid(true);
     }
     public static function getTotalsByRange($from, $to, $limit = 0)
     {

--- a/src/CommunityStore/Utilities/Installer.php
+++ b/src/CommunityStore/Utilities/Installer.php
@@ -304,11 +304,12 @@ class Installer
         $table = StoreOrderStatus::getTableName();
         $db = \Database::connection();
         $statuses = array(
-            array('osHandle' => 'incomplete', 'osName' => t('Incomplete'), 'osInformSite' => 1, 'osInformCustomer' => 0, 'osIsStartingStatus' => 0),
-            array('osHandle' => 'pending', 'osName' => t('Pending'), 'osInformSite' => 1, 'osInformCustomer' => 1, 'osIsStartingStatus' => 1),
-            array('osHandle' => 'processing', 'osName' => t('Processing'), 'osInformSite' => 1, 'osInformCustomer' => 1, 'osIsStartingStatus' => 0),
+            array('osHandle' => 'incomplete', 'osName' => t('Awaiting Processing'), 'osInformSite' => 1, 'osInformCustomer' => 0, 'osIsStartingStatus' => 1),
+            array('osHandle' => 'processing', 'osName' => t('Processing'), 'osInformSite' => 1, 'osInformCustomer' => 0, 'osIsStartingStatus' => 0),
             array('osHandle' => 'shipped', 'osName' => t('Shipped'), 'osInformSite' => 1, 'osInformCustomer' => 1, 'osIsStartingStatus' => 0),
-            array('osHandle' => 'complete', 'osName' => t('Complete'), 'osInformSite' => 1, 'osInformCustomer' => 1, 'osIsStartingStatus' => 0),
+            array('osHandle' => 'delivered', 'osName' => t('Delivered'), 'osInformSite' => 1, 'osInformCustomer' => 1, 'osIsStartingStatus' => 0),
+            array('osHandle' => 'nodelivery', 'osName' => t('Will not deliver'), 'osInformSite' => 1, 'osInformCustomer' => 1, 'osIsStartingStatus' => 0),
+            array('osHandle' => 'returned', 'osName' => t('Returned'), 'osInformSite' => 1, 'osInformCustomer' => 0, 'osIsStartingStatus' => 0),
         );
         foreach ($statuses as $status) {
             $row = $db->GetRow("SELECT * FROM " . $table . " WHERE osHandle=?", array($status['osHandle']));

--- a/src/CommunityStore/Utilities/Installer.php
+++ b/src/CommunityStore/Utilities/Installer.php
@@ -311,14 +311,11 @@ class Installer
             array('osHandle' => 'nodelivery', 'osName' => t('Will not deliver'), 'osInformSite' => 1, 'osInformCustomer' => 1, 'osIsStartingStatus' => 0),
             array('osHandle' => 'returned', 'osName' => t('Returned'), 'osInformSite' => 1, 'osInformCustomer' => 0, 'osIsStartingStatus' => 0),
         );
+
+        $db->query("DELETE FROM " . $table);
+
         foreach ($statuses as $status) {
-            $row = $db->GetRow("SELECT * FROM " . $table . " WHERE osHandle=?", array($status['osHandle']));
-            if (!isset($row['osHandle'])) {
-                StoreOrderStatus::add($status['osHandle'], $status['osName'], $status['osInformSite'], $status['osInformCustomer'], $status['osIsStartingStatus']);
-            } else {
-                $orderStatus = StoreOrderStatus::getByID($row['osID']);
-                $orderStatus->update($status, true);
-            }
+            StoreOrderStatus::add($status['osHandle'], $status['osName'], $status['osInformSite'], $status['osInformCustomer'], $status['osIsStartingStatus']);
         }
     }
 


### PR DESCRIPTION
This adds Paid, Refunded and Cancelled statuses to orders, all tracked by the user who performed them. These actions can be reversed if mistakes are made too.

Payment gateways default to marking orders a paid when used, but methods like the 'Invoice' type can be (and has been) configured to not mark as paid - i.e. a payment has to be manually confirmed.

Existing order statuses are now treated as fulfillment statuses. 

This also adds in payment instructions to emails.

The only thing this PR might need is a script on upgrade to update existing orders in existing shops. 
I'm thinking it would be 'if the order has a transaction number, update the paid date the same as the ordered date'. Open to suggestions here.
