### PR TITLE
filter and search functionality

### DIFF
--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -74,7 +74,15 @@ if (is_object($product) && $product->isActive()) {
                             <span class="store-product-featured"><?= t("Featured Item") ?></span>
                         <?php }
                     } ?>
-
+                    <?php if(is_array($product->getAttributes())) :
+                        foreach($product->getAttributes() as $aName => $value){ ?>
+                          <div class="store-product-attributes">
+                            <strong><?= t($aName) ?>:</strong>
+                            <?= $value ?>
+                          </div>
+                    <?php   }
+                          endif;
+                    ?>
                     <div class="store-product-options" id="product-options-<?= $bID; ?>">
                         <?php if ($product->allowQuantity() && $showQuantity) { ?>
                             <div class="store-product-quantity form-group">

--- a/blocks/community_product_list/controller.php
+++ b/blocks/community_product_list/controller.php
@@ -9,7 +9,8 @@ use Database;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product as StoreProduct;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductList as StoreProductList;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Group\GroupList as StoreGroupList;
-
+use Concrete\Package\CommunityStore\Src\Attribute\Key\StoreProductKey;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Group\Group as StoreGroup;
 class Controller extends BlockController
 {
     protected $btTable = 'btCommunityStoreProductList';
@@ -32,7 +33,9 @@ class Controller extends BlockController
         $this->requireAsset('css', 'select2');
         $this->requireAsset('javascript', 'select2');
         $this->getGroupList();
-        $this->set('groupfilters', array());
+        $this->set('groupfilters', $this->getGroupFilters());
+        $this->set("attributeList", $this->getAttributeKeyValueList());
+        $this->set('attributefilters',$this->getAttributeFilters());
     }
     public function edit()
     {
@@ -41,10 +44,15 @@ class Controller extends BlockController
         $this->getGroupList();
         $this->set('groupfilters', $this->getGroupFilters());
 
+
         if ($this->relatedPID) {
             $relatedProduct = StoreProduct::getByID($this->relatedPID);
             $this->set('relatedProduct', $relatedProduct);
         }
+
+        $this->set("attributeList", $this->getAttributeKeyValueList());
+        $this->set('attributefilters',$this->getAttributeFilters());
+
     }
 
     public function getGroupFilters()
@@ -72,6 +80,8 @@ class Controller extends BlockController
     {
         $products = new StoreProductList();
         $products->setSortBy($this->sortOrder);
+
+        $filters = Array();
 
         if ($this->sortOrder == 'alpha') {
             $products->setSortByDirection('asc');
@@ -117,11 +127,92 @@ class Controller extends BlockController
 
 
         $products->setItemsPerPage($this->maxProducts > 0 ? $this->maxProducts : 1000);
-        $products->setGroupIDs($this->getGroupFilters());
+
+        //group filter
+        if(!empty($this->get('group-filter'))){
+          $products->setGroupIDs($this->get('group-filter'));
+          $filters['group-filter'] = $this->get('group-filter');
+        }else {
+          //$products->setGroupIDs($this->getGroupFilters());
+          $filters['group-filter'] = Array();
+        }
+
+        //set group list
+        if(!empty($this->getGroupFilters())){
+          $grouplist = Array();
+          foreach($this->getGroupFilters() as $groupID){
+            $grouplist[] = StoreGroup::getByID($groupID);
+          }
+          $this->set('grouplist', $grouplist);
+        }
+
+        //attribute filter
+        if(!empty($this->get('attribute-filter'))){
+          $attributeIDs = Array();
+          $products->setAttributeVals($this->get('attribute-filter'));
+          $filters['attribute-filter'] = $this->get('attribute-filter');
+        }else {
+          $filters['attribute-filter'] = Array();
+        }
+        if(!empty($this->getAttributeFilters())){
+          $this->set('akvList',$this->getAttributeKeyValueList($this->getAttributeFilters()));
+        }
+
+
+
+        //keyword filter
+        if($this->get('keywords')){
+          $products->setSearch($this->get('keywords'));
+          $products->setAttributeSearch($this->get('keywords'));
+          $filters['keywords'] = $this->get('keywords');
+        }
+
+        //price filter
+        if($this->get('minprice-filter')){
+          $filters['minPrice'] = $this->get('minprice-filter');
+          $products->setMinPrice($this->get('minprice-filter'));
+        }
+        if($this->get('maxprice-filter')){
+          $filters['maxPrice'] = $this->get('maxprice-filter');
+          $products->setMaxPrice($this->get('maxprice-filter'));
+        }
+        //width filter
+        if($this->get('minwidth-filter')){
+          $filters['minWidth'] = $this->get('minwidth-filter');
+          $products->setMinWidth($this->get('minwidth-filter'));
+        }
+        if($this->get('maxwidth-filter')){
+          $filters['maxWidth'] = $this->get('maxwidth-filter');
+          $products->setMaxWidth($this->get('maxwidth-filter'));
+        }
+        //height filter
+        if($this->get('minheight-filter')){
+          $filters['minHeight'] = $this->get('minheight-filter');
+          $products->setMinHeight($this->get('minheight-filter'));
+        }
+        if($this->get('maxheight-filter')){
+          $filters['maxHeight'] = $this->get('maxheight-filter');
+          $products->setMaxHeight($this->get('maxheight-filter'));
+        }
+
+        //length filter
+        if($this->get('minlength-filter')){
+          $filters['minLength'] = $this->get('minlength-filter');
+          $products->setMinLength($this->get('minlength-filter'));
+        }
+        if($this->get('maxlength-filter')){
+          $filters['maxLength'] = $this->get('maxlength-filter');
+          $products->setMaxLength($this->get('maxlength-filter'));
+        }
+
+
+
         $products->setFeaturedOnly($this->showFeatured);
         $products->setSaleOnly($this->showSale);
         $products->setShowOutOfStock($this->showOutOfStock);
         $products->setGroupMatchAny($this->groupMatchAny);
+
+
         $paginator = $products->getPagination();
         $pagination = $paginator->renderDefaultView();
         $products = $paginator->getCurrentPageResults();
@@ -141,6 +232,28 @@ class Controller extends BlockController
         if (Config::get('community_store.shoppingDisabled') == 'all') {
             $this->set('showAddToCart', false);
         }
+
+        //set filters
+        $this->set('filters', $filters);
+        //setting minimum and maximum range of price range slider
+        $maxMinPrices = $this->getMaxMinPrice();
+        $this->set('maxPrice', $maxMinPrices['max']);
+        $this->set('minPrice', $maxMinPrices['min']);
+        //setting minimum and maximum range of width
+        $maxMinWidth = $this->getMaxMinWidth();
+        $this->set('maxWidth', $maxMinWidth['max']);
+        $this->set('minWidth', $maxMinWidth['min']);
+        //setting minimum and maximum range of height
+        $maxMinHeight = $this->getMaxMinHeight();
+        $this->set('maxHeight', $maxMinHeight['max']);
+        $this->set('minHeight', $maxMinHeight['min']);
+        //setting minimum and maximum range of length
+        $maxMinLength = $this->getMaxMinLength();
+        $this->set('maxLength', $maxMinLength['max']);
+        $this->set('minLength', $maxMinLength['min']);
+
+
+
     }
     public function registerViewAssets($outputContent = '')
     {
@@ -149,6 +262,7 @@ class Controller extends BlockController
         $this->addFooterItem($js);
         $this->requireAsset('javascript', 'community-store');
         $this->requireAsset('css', 'community-store');
+        $this->requireAsset('jquery/ui');
     }
     public function save($args)
     {
@@ -166,6 +280,12 @@ class Controller extends BlockController
         $args['showSale'] = isset($args['showSale']) ? 1 : 0;
         $args['maxProducts'] = (isset($args['maxProducts']) && $args['maxProducts'] > 0) ? $args['maxProducts'] : 0;
 
+        $args['showWidthFilter'] = isset($args['showWidthFilter']) ? 1 : 0;
+        $args['showHeightFilter'] = isset($args['showHeightFilter']) ? 1 : 0;
+        $args['showLengthFilter'] = isset($args['showLengthFilter']) ? 1 : 0;
+        $args['showPriceFilter'] = isset($args['showPriceFilter']) ? 1 : 0;
+        $args['showKeywordFilter'] = isset($args['showKeywordFilter']) ? 1 : 0;
+
         $filtergroups = $args['filtergroups'];
         unset($args['filtergroups']);
 
@@ -178,6 +298,19 @@ class Controller extends BlockController
             foreach ($filtergroups as $gID) {
                 $vals = array($this->bID, (int) $gID);
                 $db->query("INSERT INTO btCommunityStoreProductListGroups (bID,gID) VALUES (?,?)", $vals);
+            }
+        }
+        //insert attributes
+        $filterattributes = $args['filterattributes'];
+        unset($args['filterattributes']);
+        $db = \Database::connection();
+        $vals = array($this->bID);
+        $db->query("DELETE FROM btCommunityStoreProductListAttributes where bID = ?", $vals);
+
+        if (!empty($filterattributes)) {
+            foreach ($filterattributes as $akID) {
+                $vals = array($this->bID, (int) $akID);
+                $db->query("INSERT INTO btCommunityStoreProductListAttributes (bID,akID) VALUES (?,?)", $vals);
             }
         }
 
@@ -197,5 +330,69 @@ class Controller extends BlockController
         }
 
         return $e;
+    }
+
+    public function getMaxMinPrice(){
+      $db = \Database::connection();
+      $r = $db->query("SELECT MAX(pPrice) as 'maxPPrice', MIN(pPrice) as 'minPPrice', MAX(pSalePrice) as 'maxSalePrice', MIN(pSalePrice) as 'minSalePrice' FROM CommunityStoreProducts");
+      $result = $r->fetchRow();
+
+      if($result['maxPPrice'] > $result['maxSalePrice']){
+        $maxPrice = $result['maxPPrice'];
+      } else {
+        $maxPrice = $result['maxSalePrice'];
+      }
+      if($result['minSalePrice']!=null && $result['minPPrice']!=null){
+        $minPrice = $result['minSalePrice'] < $result['minPPrice'] ? $result['minSalePrice'] :  $result['minPPrice'];
+      }else if($result['minSalePrice']==null){
+        $minPrice = $result['minPPrice'];
+      }else if($result['minPPrice']==null){
+        $minPrice = $result['minSalePrice'];
+      }else {
+        $minPrice = 0;
+      }
+      $maxMinPrices['max'] = $maxPrice;
+      $maxMinPrices['min'] = $minPrice;
+      return($maxMinPrices);
+    }
+    public function getMaxMinWidth(){
+      $db = \Database::connection();
+      $r = $db->query("SELECT MAX(pWidth) as 'max', MIN(pWidth) as 'min' FROM CommunityStoreProducts");
+      $result = $r->fetchRow();
+      return $result;
+    }
+
+    public function getMaxMinHeight(){
+      $db = \Database::connection();
+      $r = $db->query("SELECT MAX(pHeight) as 'max', MIN(pHeight) as 'min' FROM CommunityStoreProducts");
+      $result = $r->fetchRow();
+      return $result;
+    }
+
+    public function getMaxMinLength(){
+      $db = \Database::connection();
+      $r = $db->query("SELECT MAX(pLength) as 'max', MIN(pLength) as 'min' FROM CommunityStoreProducts");
+      $result = $r->fetchRow();
+      return $result;
+    }
+
+    public function getAttributeKeyValueList($akIDs = array()){
+      $list = StoreProductKey::getAttributeKeyValueList($akIDs);
+      return $list;
+    }
+
+    public function getAttributeFilters()
+    {
+        $db = \Database::connection();
+        $result = $db->query("SELECT akID FROM btCommunityStoreProductListAttributes where bID = ?", array($this->bID));
+
+        $list = array();
+
+        if ($result) {
+            foreach ($result as $ak) {
+                $list[] = $ak['akID'];
+            }
+        }
+        return $list;
     }
 }

--- a/blocks/community_product_list/db.xml
+++ b/blocks/community_product_list/db.xml
@@ -28,10 +28,19 @@
 		<field name="showAddToCart" type="boolean"><default value="1"/></field>
 		<field name="btnText" type="string" size="255"></field>
 		<field name="showQuantity" type="boolean"></field>
+		<field name="showWidthFilter" type="boolean"></field>
+		<field name="showHeightFilter" type="boolean"></field>
+		<field name="showLengthFilter" type="boolean"></field>
+		<field name="showPriceFilter" type="boolean"></field>
+		<field name="showKeywordFilter" type="boolean"></field>
 	</table>
 
 	<table name="btCommunityStoreProductListGroups">
 		<field name="bID" type="integer" size="10"><unsigned /></field>
 		<field name="gID" type="integer" size="10"><unsigned/></field>
+	</table>
+	<table name="btCommunityStoreProductListAttributes">
+		<field name="bID" type="integer" size="10"><unsigned /></field>
+		<field name="akID" type="integer" size="10"><unsigned/></field>
 	</table>
 </schema>

--- a/blocks/community_product_list/form.php
+++ b/blocks/community_product_list/form.php
@@ -1,4 +1,6 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+
+use Concrete\Package\CommunityStore\Src\Attribute\Value\StoreProductValue as StoreProductValue; ?>
 
 <div class="row">
 
@@ -43,13 +45,9 @@
         <fieldset>
             <legend><?= t('Filtering') ?></legend>
 
-            <?php
-            foreach ($grouplist as $productgroup) {
-                $productgroups[$productgroup->getGroupID()] = $productgroup->getGroupName();
-            }
-            ?>
 
-            <?php if (!empty($productgroups)) { ?>
+
+            <?php if (!empty($grouplist)) { ?>
 
                 <div class="form-group">
                     <?= $form->label('gID', t('Filter by Product Groups')); ?>
@@ -57,9 +55,9 @@
                     <div class="ccm-search-field-content ccm-search-field-content-select2">
                         <select multiple="multiple" name="filtergroups[]" id="groups-select"
                                 class="existing-select2 select2-select" style="width: 100%" placeholder="<?= t('Select Product Groups') ?>">
-                            <?php foreach ($productgroups as $pgkey => $pglabel) { ?>
+                            <?php foreach ($grouplist as $productgroup) { ?>
                                 <option
-                                    value="<?= $pgkey; ?>" <?= (in_array($pgkey, $groupfilters) ? 'selected="selected"' : ''); ?>><?= $pglabel; ?></option>
+                                    value="<?= $productgroup->getGroupID(); ?>" <?= (in_array($productgroup->getGroupID(), $groupfilters) ? 'selected="selected"' : ''); ?>><?php echo $productgroup->getGroupName()." (".$productgroup->getNumProducts().")"; ?></option>
                             <?php } ?>
                         </select>
                     </div>
@@ -70,15 +68,77 @@
                     <?= $form->label('groupMatchAny', t('Matching')); ?>
                     <?= $form->select('groupMatchAny', array('0' => t("All groups selected"), '1' => t('Any group selected')), $groupMatchAny); ?>
                 </div>
-
+                <style>
+                .select2-container {
+                  z-index: 2000;
+                }
+                </style>
             <?php } ?>
 
+
+            <?php
+            if(!empty($attributeList)){
+              foreach ($attributeList as $key => $val) {
+                  $attributes[$key] = $val['name'];
+              }
+            }
+            ?>
+            <?php if (!empty($attributes)) { ?>
+                <?= $form->label('attributes', t('Filter by Product Attributes')); ?>
+                <div class="form-group">
+                    <div class="ccm-search-field-content ccm-search-field-content-select2">
+                        <select multiple="multiple" name="filterattributes[]" id="attributes-select"
+                                class="existing-select2 select2-select" style="width: 100%" placeholder="<?= t('Select Product Attributes') ?>">
+                            <?php foreach ($attributes as $akey => $alabel) { ?>
+                                <option
+                                    value="<?= $akey; ?>" <?= (in_array($akey, $attributefilters) ? 'selected="selected"' : ''); ?>><?= $alabel; ?></option>
+                            <?php } ?>
+                        </select>
+                    </div>
+                </div>
+                <style>
+                .select2-container {
+                  z-index: 2000;
+                }
+                </style>
+
+            <?php } ?>
             <div class="form-group checkbox">
                 <label>
-                    <?= $form->checkbox('showFeatured', 1, $showFeatured); ?>
-                    <?= t('Include Featured Only') ?>
+                    <?= $form->checkbox('showWidthFilter', 1, $showWidthFilter); ?>
+                    <?= t('Show Width Filter') ?>
                 </label>
             </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showHeightFilter', 1, $showHeightFilter); ?>
+                    <?= t('Show Height Filter') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showLengthFilter', 1, $showLengthFilter); ?>
+                    <?= t('Show Length Filter') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showPriceFilter', 1, $showPriceFilter); ?>
+                    <?= t('Show Price Filter') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                <label>
+                    <?= $form->checkbox('showKeywordFilter', 1, $showKeywordFilter); ?>
+                    <?= t('Show Keyword Filter') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                 <label>
+                    <?= $form->checkbox('showFeatured', 1, $showFeatured); ?>
+                    <?= t('Include Featured Only') ?>
+                 </label>
+             </div>
             <div class="form-group checkbox">
                 <label>
                     <?= $form->checkbox('showSale', 1, $showSale); ?>
@@ -212,6 +272,7 @@ if ($relatedProduct) {
 
 
         $('#groups-select').select2();
+        $('#attributes-select').select2();
 
         var initfilter = $('#filter');
 
@@ -264,6 +325,3 @@ if ($relatedProduct) {
         });
     });
 </script>
-
-
-

--- a/blocks/community_product_list/js/jquery.ui.touch-punch.min.js
+++ b/blocks/community_product_list/js/jquery.ui.touch-punch.min.js
@@ -1,0 +1,11 @@
+/*!
+ * jQuery UI Touch Punch 0.2.3
+ *
+ * Copyright 2011–2014, Dave Furfero
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
+ */
+!function(a){function f(a,b){if(!(a.originalEvent.touches.length>1)){a.preventDefault();var c=a.originalEvent.changedTouches[0],d=document.createEvent("MouseEvents");d.initMouseEvent(b,!0,!0,window,1,c.screenX,c.screenY,c.clientX,c.clientY,!1,!1,!1,!1,0,null),a.target.dispatchEvent(d)}}if(a.support.touch="ontouchend"in document,a.support.touch){var e,b=a.ui.mouse.prototype,c=b._mouseInit,d=b._mouseDestroy;b._touchStart=function(a){var b=this;!e&&b._mouseCapture(a.originalEvent.changedTouches[0])&&(e=!0,b._touchMoved=!1,f(a,"mouseover"),f(a,"mousemove"),f(a,"mousedown"))},b._touchMove=function(a){e&&(this._touchMoved=!0,f(a,"mousemove"))},b._touchEnd=function(a){e&&(f(a,"mouseup"),f(a,"mouseout"),this._touchMoved||f(a,"click"),e=!1)},b._mouseInit=function(){var b=this;b.element.bind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),c.call(b)},b._mouseDestroy=function(){var b=this;b.element.unbind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),d.call(b)}}}(jQuery);

--- a/blocks/community_product_list/view.css
+++ b/blocks/community_product_list/view.css
@@ -1,3 +1,32 @@
 .store-original-price {
     text-decoration: line-through;
 }
+
+.min-max-values {
+  border:0;
+  color:#f6931f;
+  font-weight:bold;
+  width: 100%;
+  font-size: 14px;
+  display: block;
+  margin-bottom: 10px;
+}
+#filter-area {
+  margin-top: 20px;
+}
+#filter-area .filter-container {
+  padding: 20px;
+  display: block;
+}
+
+#filter-area .slider {
+  margin: 0 10px;
+}
+#filter-area .slider.ui-slider .ui-slider-range {
+  transition: none;
+}
+
+#filter-area .filter-container .list-area {
+  max-height: 250px;
+  overflow-y: scroll;
+}

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -1,9 +1,118 @@
 <?php
 defined('C5_EXECUTE') or die(_("Access Denied."));
 use \Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation as StoreProductVariation;
+use Concrete\Package\CommunityStore\Src\Attribute\Value\StoreProductValue as StoreProductValue;
 $c = Page::getCurrentPage();
+?>
+<?php
+ if(!empty($grouplist) || !empty($akvList) || $showWidthFilter || $showHeightFilter || $showLengthFilter || $showPriceFilter || $showKeywordFilter){
+   $hasFilters = true;
+ } else{
+   $hasFilters = false;
+ }
+?>
+<div class="row">
+<div <?= $hasFilters ? 'class="col-sm-3"' : 'style="display:none;"'?> id="filter-area">
+  <a class="btn btn-default  btn-block" href="#" role="button" id="showFilters"><?php echo t('Hide Filters');?></a>
+  <form role="form" class="ccm-search-fields" id="filterForm">
+    <div class="row filter-container">
+      <?php if(!empty($grouplist)): ?>
+        <div class="form-group">
+          <label for="group-filter"><?php echo t('Groups');?>:</label>
+          <div class="list-area">
+          <?php foreach($grouplist as $group):?>
+          <div class="checkbox">
+              <label>
+                <input name="group-filter[]" type="checkbox" id="group_<?php echo $group->getGroupID(); ?>" value="<?php echo $group->getGroupID();?>" <?php echo in_array($group->getGroupID(),$filters['group-filter']) ? 'checked' : ''; ?>><?php echo $group->getGroupName()." (".$group->getNumProducts().")"; ?>
+              </label>
+          </div>
+          <?php endforeach;?>
+          </div>
+        </div>
+      <?php endif; ?> <!-- END OF GROUP FILTER -->
+      <?php if(!empty($akvList)): ?>
+        <div class="form-group">
+          <?php foreach($akvList as $id => $akv):?>
+            <label for="<?php echo $akv['name']?>"><?php echo $akv['name']?>:</label>
+            <div class="list-area">
+              <?php
+              if (is_array($akv['values']) || is_object($akv['values']))
+              {
+                foreach($akv['values'] as $key => $val){?>
+                  <?php $attrNumProducts = StoreProductValue::getNumProducts($id,$key);?>
+                  <div class="checkbox">
+                      <label>
+                        <input name="attribute-filter[<?php echo $id; ?>][]" type="checkbox" id="attribute_<?php echo $id; ?>" value="<?php echo $key?>" <?php echo is_array($filters['attribute-filter'][$id]) && in_array($key,$filters['attribute-filter'][$id]) ? 'checked' : ''; ?> >
+                        <?php echo "{$val} ({$attrNumProducts})"; ?>
+                      </label>
+                  </div>
+                <?php }
+              } ?>
+            </div>
+          <?php endforeach;?>
+        </div>
+      <?php endif; ?> <!-- END OF GROUP FILTER -->
+      <?php if ($showWidthFilter) { ?>
+        <div class="form-group">
+          <label for="width"><?php echo t('Width');?> (<?= Config::get('community_store.sizeUnit'); ?>):</label>
+          <span id="width-range" class="min-max-values"></span>
+          <input type="hidden" id="minwidth-filter" name="minwidth-filter" class="lower-value" value="<?php echo $filters['minWidth']!=null ? $filters['minWidth'] : $minWidth; ?>">
+          <input type="hidden" id="maxwidth-filter" name="maxwidth-filter" class="higher-value" value="<?php echo $filters['maxWidth']!=null ? $filters['maxWidth'] : $maxWidth; ?>">
+          <div id="slider-width-range" class="slider"></div>
+        </div>
+      <?php } ?>
+      <?php if ($showHeightFilter) { ?>
+        <div class="form-group">
+          <label for="height"><?php echo t('Height');?> (<?= Config::get('community_store.sizeUnit'); ?>):</label>
+          <span id="height-range" class="min-max-values"></span>
+          <input type="hidden" id="minheight-filter" name="minheight-filter" class="lower-value" value="<?php echo $filters['minHeight']!=null ? $filters['minHeight'] : $minHeight; ?>">
+          <input type="hidden" id="maxheight-filter" name="maxheight-filter" class="higher-value" value="<?php echo $filters['maxHeight']!=null ? $filters['maxHeight'] : $maxHeight; ?>">
+          <div id="slider-height-range" class="slider"></div>
+        </div>
+      <?php } ?>
+      <?php if ($showLengthFilter) { ?>
+        <div class="form-group">
+          <label for="length"><?php echo t('Length');?> (<?= Config::get('community_store.sizeUnit'); ?>):</label>
+          <span id="length-range" class="min-max-values"></span>
+          <input type="hidden" id="minlength-filter" name="minlength-filter" class="lower-value" value="<?php echo $filters['minLength']!=null ? $filters['minLength'] : $minLength; ?>">
+          <input type="hidden" id="maxlength-filter" name="maxlength-filter" class="higher-value" value="<?php echo $filters['maxLength']!=null ? $filters['maxLength'] : $maxLength; ?>">
+          <div id="slider-length-range" class="slider"></div>
+        </div>
+      <?php } ?>
+      <?php if ($showPriceFilter) { ?>
+        <div class="form-group">
+          <label for="amount"><?php echo t('Price');?> (<?=  Config::get('community_store.symbol'); ?>):</label>
+          <span id="price-range" class="min-max-values"></span>
+          <input type="hidden" id="minprice-filter" name="minprice-filter" class="lower-value" value="<?php echo $filters['minPrice']!=null ? $filters['minPrice'] : $minPrice; ?>">
+          <input type="hidden" id="maxprice-filter" name="maxprice-filter" class="higher-value" value="<?php echo $filters['maxPrice']!=null ? $filters['maxPrice'] : $maxPrice; ?>">
+          <div id="slider-price-range" class="slider"></div>
+        </div>
+      <?php } ?>
+      <?php if ($showKeywordFilter) { ?>
+        <div class="form-group">
+          <label for="keywords"><?php echo t('Keywords');?>:</label>
+            <?= $form->search('keywords', $filters['keywords'], array('placeholder' => t('Search Name, Description or SKU')))?>
+        </div>
+      <?php } ?>
+      <?php if ($hasFilters) { ?>
+      <div class="btn-group btn-group-justified" role="group" aria-label="..." style="margin-top : 10px;">
+        <div class="btn-group" role="group">
+          <button type="submit" class="btn btn-primary"><?= t('Search')?></button>
+        </div>
+        <div class="btn-group" role="group">
+          <input id="reset-button" type="button" class="btn btn-default" value="<?= t('Clear')?>"/>
+        </div>
+      </div>
+      <?php } ?>
+    </div>
+  </form>
+</div>
 
+
+<div class="<?= $hasFilters ? 'col-sm-9' : 'col-sm-12'?>">
+<?php
 if($products){
+
     $columnClass = 'col-md-12';
 
     if ($productsPerRow == 2) {
@@ -45,11 +154,11 @@ if($products){
         }
 
     ?>
-    
+
         <div class="store-product-list-item <?= $columnClass; ?> <?= $activeclass; ?>">
             <form   id="store-form-add-to-cart-list-<?= $product->getID()?>">
                 <h2 class="store-product-list-name"><?= $product->getName()?></h2>
-                <?php 
+                <?php
                     $imgObj = $product->getImageObj();
                     if(is_object($imgObj)){
                         $thumb = $ih->getThumbnail($imgObj,400,280,true);?>
@@ -84,6 +193,22 @@ if($products){
                 <?php } ?>
                 <?php if($showDescription){ ?>
                 <div class="store-product-list-description"><?= $product->getDesc()?></div>
+                <?php } ?>
+                <?php if(is_array($product->getAttributes())) :
+                        foreach($product->getAttributes() as $aName => $value){ ?>
+                          <div class="store-product-attributes">
+                            <strong><?= t($aName) ?>:</strong>
+                            <?= $value ?>
+                          </div>
+                <?php   }
+                      endif;
+                ?>
+                <?php if ($showDimensions) { ?>
+                    <div class="store-product-dimensions">
+                        <strong><?= t("Dimensions") ?>:</strong>
+                        <?= $product->getDimensions() ?>
+                        <?= Config::get('community_store.sizeUnit'); ?>
+                    </div>
                 <?php } ?>
                 <?php if($showPageLink){?>
                 <p class="store-btn-more-details-container"><a href="<?= \URL::to(Page::getByID($product->getPageID()))?>" class="store-btn-more-details btn btn-default"><?= ($pageLinkText ? $pageLinkText : t("More Details"))?></a></p>
@@ -198,18 +323,18 @@ if($products){
 
             </form><!-- .product-list-item-inner -->
         </div><!-- .product-list-item -->
-        
-        <?php 
+
+        <?php
             if($i%$productsPerRow==0){
                 echo "</div>";
                 echo '<div class="store-product-list row store-product-list-per-row-'. $productsPerRow .'">';
             }
-        
+
         $i++;
-    
-    }// foreach    
+
+    }// foreach
     echo "</div><!-- .product-list -->";
-    
+
     if($showPagination){
         if ($paginator->getTotalPages() > 1) {
             echo '<div class="row">';
@@ -217,8 +342,124 @@ if($products){
             echo '</div>';
         }
     }
-    
+
 } //if products
 elseif (is_object($c) && $c->isEditMode()) { ?>
-    <p class="alert alert-info"><?= t("Empty Product List")?></p>
+   <p class="alert alert-info"><?= t("Empty Product List")?></p>
 <?php } ?>
+</div>
+</div>
+<script>
+$( function() {
+  <?php if ($showPriceFilter) { ?>
+  $( "#slider-price-range" ).slider({
+    range: true,
+    step: <?php echo ($maxPrice - $minPrice) > 5 ? ($maxPrice - $minPrice) / 5 : 1 ?>,
+    min: <?php echo $minPrice; ?>,
+    max:  <?php echo $maxPrice; ?>,
+    values: [ <?php echo $filters['minPrice']!=null ? $filters['minPrice'] : $minPrice; ?>, <?php echo $filters['maxPrice']!=null ? $filters['maxPrice'] : $maxPrice; ?> ],
+    slide: function( event, ui ) {
+      $( "#price-range" ).text(  ui.values[ 0 ] + " - " + ui.values[ 1 ] );
+      $("#minprice-filter").val(ui.values[ 0 ]);
+      $("#maxprice-filter").val(ui.values[ 1 ]);
+    }
+  });
+  $( "#price-range" ).text( $( "#slider-price-range" ).slider( "values", 0 ) +
+    " - " + $( "#slider-price-range" ).slider( "values", 1 ) );
+  <?php } ?>
+  <?php if ($showWidthFilter) { ?>
+  $( "#slider-width-range" ).slider({
+    range: true,
+    step: <?php echo ($maxWidth - $minWidth) > 5 ? ($maxWidth - $minWidth) / 5 : 1 ?>,
+    min: <?php echo $minWidth; ?>,
+    max:  <?php echo $maxWidth; ?>,
+    values: [ <?php echo $filters['minWidth']!=null ? $filters['minWidth'] : $minWidth; ?>, <?php echo $filters['maxWidth']!=null ? $filters['maxWidth'] : $maxWidth; ?> ],
+    slide: function( event, ui ) {
+      $( "#width-range" ).text(  ui.values[ 0 ] + " - " + ui.values[ 1 ] );
+      $("#minwidth-filter").val(ui.values[ 0 ]);
+      $("#maxwidth-filter").val(ui.values[ 1 ]);
+    }
+  });
+  $( "#width-range" ).text( $( "#slider-width-range" ).slider( "values", 0 ) +
+    " - " + $( "#slider-width-range" ).slider( "values", 1 ) );
+  <?php } ?>
+  <?php if ($showHeightFilter) { ?>
+  $( "#slider-height-range" ).slider({
+    range: true,
+    step: <?php echo ($maxHeight - $minHeight) > 5 ? ($maxHeight - $minHeight) / 5 : 1 ?>,
+    min: <?php echo $minHeight; ?>,
+    max:  <?php echo $maxHeight; ?>,
+    values: [ <?php echo $filters['minHeight']!=null ? $filters['minHeight'] : $minHeight; ?>, <?php echo $filters['maxHeight']!=null ? $filters['maxHeight'] : $maxHeight; ?> ],
+    slide: function( event, ui ) {
+      $( "#height-range" ).text(  ui.values[ 0 ] + " - " + ui.values[ 1 ] );
+      $("#minheight-filter").val(ui.values[ 0 ]);
+      $("#maxheight-filter").val(ui.values[ 1 ]);
+    }
+  });
+  $( "#height-range" ).text( $( "#slider-height-range" ).slider( "values", 0 ) +
+    " - " + $( "#slider-height-range" ).slider( "values", 1 ) );
+
+  <?php } ?>
+  <?php if ($showLengthFilter) { ?>
+    $( "#slider-length-range" ).slider({
+      range: true,
+      step: <?php echo ($maxLength - $minLength) > 5 ? ($maxLength - $minLength) / 5 : 1 ?>,
+      min: <?php echo $minLength; ?>,
+      max:  <?php echo $maxLength; ?>,
+      values: [ <?php echo $filters['minLength']!=null ? $filters['minLength'] : $minLength; ?>, <?php echo $filters['maxLength']!=null ? $filters['maxLength'] : $maxLength; ?> ],
+      slide: function( event, ui ) {
+        $( "#length-range" ).text(  ui.values[ 0 ] + " - " + ui.values[ 1 ] );
+        $("#minlength-filter").val(ui.values[ 0 ]);
+        $("#maxlength-filter").val(ui.values[ 1 ]);
+      }
+    });
+    $( "#length-range" ).text( $( "#slider-length-range" ).slider( "values", 0 ) +
+      " - " + $( "#slider-length-range" ).slider( "values", 1 ) );
+  <?php } ?>
+  <?php if ($hasFilters) { ?>
+  $('#reset-button').on('click', function(){
+    $(':input').not(':button, :submit, :reset, :hidden, :checkbox, :radio').val('');
+    $(':checkbox, :radio').prop('checked', false);
+    $('.slider').each(function(){
+      var options = $(this).slider( 'option' );
+      $(this).slider( 'values', [ options.min, options.max ] );
+      $(this).siblings('.lower-value').val(options.min);
+      $(this).siblings('.higher-value').val(options.max);
+      $(this).siblings('.min-max-values').text(  options.min + " - " + options.max );
+    });
+
+  });
+  $('.slider').each(function(){
+    $(this).draggable();
+  });
+  $('#showFilters').click(function(e){
+    $('.filter-container').toggle();
+    if($('.filter-container').is(":visible") == false){
+      $('#showFilters').text(<?php echo "'" . t('Show Filters') . "'"; ?>);
+    }else{
+      $('#showFilters').text(<?php echo "'" . t('Hide Filters') . "'"; ?>);
+    }
+    e.preventDefault();
+  });
+  $(window).on('resize', function(){
+    if($(window).width() > 767){
+      $('#showFilters').hide();
+      if($('.filter-container').is(":visible") == false){
+        $('.filter-container').show();
+        $('#showFilters').text(<?php echo "'" . t('Hide Filters') . "'"; ?>);
+      }
+    }else{
+      $('#showFilters').show();
+    }
+  });
+  $(document).ready(function(){
+    if($(window).width() > 767){
+      $('#showFilters').hide();
+    }else{
+      $('#showFilters').show();
+    }
+  });
+  <?php } ?>
+
+} );
+</script>

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -61,13 +61,13 @@ class Products extends DashboardPageController
 
         $grouplist = StoreGroupList::getGroupList();
         $this->set("grouplist",$grouplist);
-        
+
     }
     public function success(){
         $this->set("success",t("Product Added"));
         $this->view();
     }
-    
+
     public function updated()
     {
         $this->set("success",t("Product Updated"));
@@ -81,7 +81,7 @@ class Products extends DashboardPageController
     {
         $this->loadFormAssets();
         $this->set("actionType",t("Add"));
-        
+
         $grouplist = StoreGroupList::getGroupList();
         $this->set("grouplist",$grouplist);
         foreach($grouplist as $productgroup){
@@ -121,7 +121,7 @@ class Products extends DashboardPageController
 
         $this->loadFormAssets();
         $this->set("actionType",t("Update"));
-        
+
         //get the product
         $product = StoreProduct::getByID($pID);
 
@@ -254,19 +254,17 @@ class Products extends DashboardPageController
         $this->requireAsset('core/sitemap');
         $this->requireAsset('css', 'select2');
         $this->requireAsset('javascript', 'select2');
-        
+
         $this->set('fp',FilePermissions::getGlobal());
         $this->set('tp', new TaskPermission());
         $this->set('al', Core::make('helper/concrete/asset_library'));
 
         $this->requireAsset('css', 'communityStoreDashboard');
         $this->requireAsset('javascript', 'communityStoreFunctions');
-        $this->requireAsset('css', 'select2');
-        $this->requireAsset('javascript', 'select2');
 
-        $attrList = StoreProductKey::getList();
+        $attrList = StoreProductKey::getAttributeKeyValueList();
         $this->set('attribs',$attrList);
-        
+
         $pageType = PageType::getByHandle("store_product");
         $pageTemplates = $pageType->getPageTypePageTemplateObjects();
         $templates = array();
@@ -293,29 +291,34 @@ class Products extends DashboardPageController
             $this->error = null; //clear errors
             $this->error = $errors;
             if (!$errors->has()) {
-                    
+
                 //save the product
                 $product = StoreProduct::saveProduct($data);
                 //save product attributes
-                $aks = StoreProductKey::getList();
-                foreach($aks as $uak) {
-                    $uak->saveAttributeForm($product);
+                if(!empty($data['akID'])){
+                  foreach($data['akID'] as $key => $value){
+                    $ak = StoreProductKey::getByID($key);
+                    if(!empty($value['value'])){
+                      $ak->saveAttribute($product,false,$value['value']);
+                    }
+                  }
                 }
+
                 //save images
                 StoreProductImage::addImagesForProduct($data,$product);
-                
+
                 //save product groups
                 StoreProductGroup::addGroupsForProduct($data,$product);
-                
+
                 //save product user groups
                 StoreProductUserGroup::addUserGroupsForProduct($data,$product);
-                
+
                 //save product options
                 StoreProductOption::addProductOptions($data,$product);
-                
+
                 //save files
                 StoreProductFile::addFilesForProduct($data,$product);
-                
+
                 //save category locations
                 StoreProductLocation::addLocationsForProduct($data,$product);
 
@@ -336,7 +339,7 @@ class Products extends DashboardPageController
     public function validate($args)
     {
         $e = Core::make('helper/validation/error');
-        
+
         if($args['pName']==""){
             $e->add(t('Please enter a Product Name'));
         }
@@ -361,11 +364,11 @@ class Products extends DashboardPageController
         if(!is_numeric($args['pWeight'])){
             $e->add(t('The Product Weight must be a number'));
         }
-        
+
         return $e;
-        
+
     }
-    
+
     // GROUPS PAGE
     public function groups()
     {
@@ -397,7 +400,7 @@ class Products extends DashboardPageController
     public function validateGroup($args)
     {
         $e = Core::make('helper/validation/error');
-        
+
         if($args['groupName']==""){
             $e->add(t('Please enter a Group Name'));
         }

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -299,7 +299,11 @@ class Products extends DashboardPageController
                   foreach($data['akID'] as $key => $value){
                     $ak = StoreProductKey::getByID($key);
                     if(!empty($value['value'])){
-                      $ak->saveAttribute($product,false,$value['value']);
+                      if($data['newAv'.$key] == "true"){
+                        $ak->saveAttribute($product,false,$value['value'],true);
+                      }else{
+                        $ak->saveAttribute($product,false,$value['value']);
+                      }
                     }
                   }
                 }

--- a/controllers/single_page/dashboard/store/products/attributes.php
+++ b/controllers/single_page/dashboard/store/products/attributes.php
@@ -12,7 +12,7 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreProductKey;
 
 class Attributes extends DashboardPageController
 {
-    
+
     public function view() {
         $this->set('category', AttributeKeyCategory::getByHandle('store_product'));
         $attrTypes = AttributeType::getList('store_product');
@@ -25,18 +25,18 @@ class Attributes extends DashboardPageController
         $this->set('types', $types);
         $this->set('pageTitle', t('Product Attributes'));
     }
-    
+
     public function update_attributes() {
         $uats = $_REQUEST['akID'];
         StoreProductKey::updateAttributesDisplayOrder($uats);
         exit;
     }
-        
+
     public function removed() {
         $this->set('message', t('Attribute Deleted.'));
         $this->view();
     }
-    
+
     public function success() {
         $this->set('message', t('Attribute Created.'));
         $this->view();
@@ -46,11 +46,11 @@ class Attributes extends DashboardPageController
         $this->set('message', t('Attribute Updated.'));
         $this->view();
     }
-    
+
     public function delete($akID, $token = null){
         try {
             $ak = StoreProductKey::getByID($akID);
-                
+
             if(!($ak instanceof StoreProductKey)) {
                 throw new Exception(t('Invalid attribute ID.'));
             }
@@ -60,9 +60,9 @@ class Attributes extends DashboardPageController
             if (!$valt->validate('delete_attribute', $token)) {
                 throw new Exception($valt->getErrorMessage());
             }
-            
+
             $ak->delete();
-            
+
             $this->redirect("/dashboard/store/products/attributes", 'removed');
         } catch (Exception $e) {
             $this->set('error', $e);
@@ -76,7 +76,7 @@ class Attributes extends DashboardPageController
         $this->set('category', AttributeKeyCategory::getByHandle('store_product'));
         $this->set('pageTitle', t('Create Product Attribute'));
     }
-    
+
     public function add() {
         $this->select_type();
         $type = $this->get('type');
@@ -90,17 +90,21 @@ class Attributes extends DashboardPageController
             $this->redirect('/dashboard/store/products/attributes/', 'success');
         }
     }
-    
+
     public function edit($akID = 0) {
         if ($this->post('akID')) {
             $akID = $this->post('akID');
         }
         $key = StoreProductKey::getByID($akID);
         $type = $key->getAttributeType();
+        $enableNumericSlider = $key->getEnableNumericSlider($akID);
+        $sliderStepValue = $key->getSliderStepValue($akID);
+        $this->set('enableNumericSlider',$enableNumericSlider);
+        $this->set('sliderStepValue',$sliderStepValue);
         $this->set('key', $key);
         $this->set('type', $type);
         $this->set('category', AttributeKeyCategory::getByHandle('store_product'));
-        
+
         if ($this->post()) {
             $cnt = $type->getController();
             $cnt->setAttributeKey($key);

--- a/db.xml
+++ b/db.xml
@@ -19,6 +19,8 @@
     </table>
     <table name="CommunityStoreProductAttributeKeys">
         <field name="akID" type="integer"><unsigned/><key/></field>
+    		<field name="enableNumericSlider" type="boolean"></field>
+        <field name="sliderStepValue" type="boolean"></field>
     </table>
     <table name="CommunityStoreProductAttributeValues">
         <field name="pID" type="integer"><unsigned/><key/></field>

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -907,24 +907,51 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product as Store
                 <?php
 
                 if (count($attribs) > 0) {
-                    foreach($attribs as $ak) {
-                        if (is_object($product)) {
-                            $caValue = $product->getAttributeValueObject($ak);
-                        }
+                  foreach($attribs as $id => $akv): ?>
+
+                  <div class="form-group">
+                  <?php
+                    if (is_object($product)) {
+                        $caValue = $product->getAttributeValueByID($id);
+                        $caValue = $caValue!=null ? $caValue->getValue() : '';
+                    }
+                    ?>
+                      <label for="<?php echo $akv['name']?>" class="control-label"><?php echo $akv['name']?>:</label>
+                      <input name="akID[<?php echo $id; ?>][value]" class="attribute-select<?php echo $id; ?>" tabindex="-1" title="" value="" type="hidden" style="width: 100%" >
+                  </div>
+
+                  <script type="text/javascript">
+                      $(document).ready(function() {
+                        var preload<?php echo $id; ?> = [];
+                        var selected<?php echo $id; ?> = [];
+                        <?php if (count($akv['values']) > 0) {
+                                foreach($akv['values'] as $key => $val){ ?>
+                                    var obj<?php echo $id; ?> = {id: <?= $key ?>, text: <?= '"' . $val . '"' ?> };
+                                    <?php if(strcmp($val,$caValue)==0){ ?>
+                                      selected<?php echo $id; ?>.push(obj<?php echo $id; ?>);
+                                    <?php } ?>
+                                    preload<?php echo $id; ?>.push(obj<?php echo $id; ?>);
+                        <?php   }
+                              }
                         ?>
-                        <div class="clearfix">
-                            <?= $ak->render('label');?>
-                            <div class="input">
-                                <?= $ak->render('composer', $caValue, true)?>
-                            </div>
-                        </div>
-                    <?php  } ?>
+                          $('.attribute-select<?php echo $id; ?>').select2({
+                            initSelection : function (element, callback) {
+                              callback(selected<?php echo $id; ?>);
+                            },
+                            placeholder: 'select or create new value',
+                            tags: preload<?php echo $id; ?>,
+                            allowClear: true,
+                            maximumSelectionSize: 1
+                          });
+                          $('.attribute-select<?php echo $id; ?>').select2("val", []);
+                      });
+                  </script>
+
+                  <?php endforeach;?>
 
                 <?php  } else {?>
                     <em><?= t('You haven\'t created product attributes')?></em>
-
                 <?php }?>
-
             </div>
 
             <div class="col-sm-9 store-pane" id="product-digital">

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -918,6 +918,7 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product as Store
                     ?>
                       <label for="<?php echo $akv['name']?>" class="control-label"><?php echo $akv['name']?>:</label>
                       <input name="akID[<?php echo $id; ?>][value]" class="attribute-select<?php echo $id; ?>" tabindex="-1" title="" value="" type="hidden" style="width: 100%" >
+                      <input type="hidden" name="newAv<?php echo $id; ?>" id="newAv<?php echo $id; ?>" value="false"/>
                   </div>
 
                   <script type="text/javascript">
@@ -942,8 +943,17 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product as Store
                             tags: preload<?php echo $id; ?>,
                             allowClear: true,
                             maximumSelectionSize: 1
+                          }).on('change', function(e){
+                            if(e.added != null){
+                              if($.inArray(e.added, preload<?php echo $id; ?>) <0){
+                                $('#newAv<?php echo $id; ?>').val("true");
+                              }else{
+                                $('#newAv<?php echo $id; ?>').val("false");
+                              }
+                            }
                           });
                           $('.attribute-select<?php echo $id; ?>').select2("val", []);
+                          $('#newAv<?php echo $id; ?>').val("false");
                       });
                   </script>
 

--- a/single_pages/dashboard/store/products/attributes.php
+++ b/single_pages/dashboard/store/products/attributes.php
@@ -1,29 +1,56 @@
-<?php 
+<?php
 defined('C5_EXECUTE') or die(_("Access Denied."));
 $addViews = array('select_type','add','edit');
 if (isset($key)) { ?>
-    
+
     <form method="post" action="<?= $this->action('edit')?>" id="ccm-attribute-key-form">
-    
+
         <?php  View::element("attribute/type_form_required", array('category' => $category, 'type' => $type, 'key' => $key)); ?>
-    
+        <?php
+        $atHandle  = $type->getAttributeTypeHandle();
+        if ($atHandle == "number"){ ?>
+          <div class="form-group">
+            <label class="control-label">Filter Settings</label>
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" name="enableNumericSlider" id="enableNumericSlider" <?php echo isset($enableNumericSlider) && $enableNumericSlider == 1 ? "checked value='1'" : "value='0'"?>> Enable slider
+              </label>
+            </div>
+            <label for="sliderStepValue" class="control-label">Slider step value </label>
+            <input type="text" class="form-control" name="sliderStepValue" id="sliderStepValue" value=" <?php echo isset($sliderStepValue) ? $sliderStepValue : "" ?>">
+          </div>
+        <?php } ?>
     </form>
 
 <?php  } elseif (in_array($controller->getTask(),$addViews)) { ?>
 
-	
+
 	<?php  if (isset($type)) { ?>
 		<form method="post" action="<?= $this->action('add')?>" id="ccm-attribute-key-form">
 		    <?php  View::element("attribute/type_form_required", array('category' => $category, 'type' => $type)); ?>
-		</form>	
+        <?php
+        $atHandle  = $type->getAttributeTypeHandle();
+         if ($atHandle == "number"){ ?>
+        <div class="form-group">
+          <label class="control-label">Filter Settings</label>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" name="enableNumericSlider" id="enableNumericSlider"> Enable slider
+            </label>
+          </div>
+          <label for="sliderStepValue" class="control-label">Slider step value </label>
+          <input type="text" class="form-control" name="sliderStepValue" id="sliderStepValue">
+        </div>
+        <?php } ?>
+    </form>
 	<?php  } ?>
-	
+
 <?php  } else {
 
 	View::element('dashboard/attributes_table', array('category' => $category, 'attribs'=> $attrList, 'editURL' => '/dashboard/store/products/attributes')); ?>
 
 	<form method="get" class="form-horizontal" action="<?= $this->action('select_type')?>" id="ccm-attribute-type-form">
-    	
+
     	<div class="form-group">
         	<div class="col-xs-12">
         	<?= $form->label('atID', t('Add Attribute'))?>
@@ -37,7 +64,7 @@ if (isset($key)) { ?>
                 </div>
         	</div>
     	</div>
-	
+
 	</form>
 
 

--- a/src/Attribute/Value/StoreProductValue.php
+++ b/src/Attribute/Value/StoreProductValue.php
@@ -36,4 +36,14 @@ class StoreProductValue extends Value
             parent::delete();
         }
     }
+
+    public function getNumProducts($akID, $avID){
+        $db = \Database::connection();
+        $result = $db->query('Select count(*) as count from CommunityStoreProductAttributeValues as av left join CommunityStoreProducts as p on av.pID = p.pID where av.akID = ? and av.avID = ? and p.pActive = 1', array(
+            $akID, $avID
+        ));
+
+        $result = $result->fetchRow();
+        return $result['count'];
+    }
 }

--- a/src/CommunityStore/Group/Group.php
+++ b/src/CommunityStore/Group/Group.php
@@ -2,16 +2,16 @@
 namespace Concrete\Package\CommunityStore\Src\CommunityStore\Group;
 
 use Database;
-
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductList as StoreProductList;
 /**
  * @Entity
  * @Table(name="CommunityStoreGroups")
  */
 class Group
 {
-    /** 
-     * @Id @Column(type="integer") 
-     * @GeneratedValue 
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
      */
     protected $gID;
 
@@ -79,5 +79,12 @@ class Group
         $em = \Database::connection()->getEntityManager();
         $em->remove($this);
         $em->flush();
+    }
+    public function getNumProducts(){
+        $products = new StoreProductList();
+        $products->setGroupIDs(array($this->gID));
+        $products->setActiveOnly(true);
+        $productCount = $products->get();
+        return count($productCount);
     }
 }

--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -32,9 +32,9 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price as StoreP
  */
 class Product
 {
-    /** 
-     * @Id @Column(type="integer") 
-     * @GeneratedValue 
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
      */
     protected $pID;
 
@@ -491,7 +491,6 @@ class Product
         } else {
             $product->setHasVariations($data['pVariations']);
         }
-
         $product->save();
         if (!$data['pID']) {
             $product->generatePage($data['selectPageTemplate']);
@@ -959,9 +958,11 @@ class Product
         $attributes = StoreProductKey::getAttributes($this->getID());
         foreach($attributes as $handle=>$value) {
             $spk = StoreProductKey::getByHandle($handle);
-            $spk->saveAttribute($newproduct, $value);
+            $akID = $spk->getAttributeKeyID();
+            $db = \Database::connection();
+            $avID = $db->GetOne("select distinct(avID) from CommunityStoreProductAttributeValues where akID = ? and pID = ?", array($akID,$this->getID()));
+            $spk->saveAttribute($newproduct, false, $avID);
         }
-
 
         $variations = $this->getVariations();
         $newvariations = array();
@@ -1087,7 +1088,7 @@ class Product
             }
         }
     }
-    public function getAttributeValueObject($ak, $createIfNotFound = false)
+    public function getAttributeValueObject($ak, $createIfNotFound = false, $newAvID = false)
     {
         $db = \Database::connection();
         $av = false;
@@ -1101,19 +1102,46 @@ class Product
             }
         }
 
+
         if ($createIfNotFound) {
-            $cnt = 0;
-
-            // Is this avID in use ?
-            if (is_object($av)) {
-                $cnt = $db->GetOne("SELECT COUNT(avID) FROM CommunityStoreProductAttributeValues WHERE avID=?", $av->getAttributeValueID());
-            }
-
-            if ((!is_object($av)) || ($cnt > 1)) {
-                $av = $ak->addAttributeValue();
+            // Removed since identifier to add new av is not the cnt
+            // if (is_object($av)) {
+                // $cnt = $db->GetOne("SELECT COUNT(avID) FROM CommunityStoreProductAttributeValues WHERE avID=?", $av->getAttributeValueID());
+            // }
+            $newAv = StoreProductValue::getByID($newAvID);
+            //create new attrib value in AttributeValues table first if there is no spav set for product
+            if ((!is_object($newAv))) {
+              //adds new av and assign as current av
+              $av = $ak->addAttributeValue();
+            }else {
+              //assign new av to as current av
+              $av = $newAv;
             }
         }
-
         return $av;
     }
+
+    public function getAttributes(){
+      $attributes = StoreProductKey::getAttributes($this->getID());
+      foreach($attributes as $handle=>$value) {
+          $ak = StoreProductKey::getByHandle($handle);
+          $display[$ak->getAttributeKeyName()] = $value;
+      }
+      return $display;
+    }
+
+    public function getAttributeValueByID($akID)
+    {
+      $db = \Database::connection();
+      $avID = $db->GetOne("SELECT avID FROM CommunityStoreProductAttributeValues WHERE pID=? AND akID=?", Array($this->getID(),$akID));
+      if ($avID > 0) {
+          $av = StoreProductValue::getByID($avID);
+          if (is_object($av)) {
+              $av->setProduct($this);
+              $av->setAttributeKey(StoreProductKey::getInstanceByID($akID));
+          }
+      }
+      return $av;
+    }
+
 }

--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -1088,7 +1088,7 @@ class Product
             }
         }
     }
-    public function getAttributeValueObject($ak, $createIfNotFound = false, $newAvID = false)
+    public function getAttributeValueObject($ak, $createIfNotFound = false, $newAvID = false, $isNew = false)
     {
         $db = \Database::connection();
         $av = false;
@@ -1108,7 +1108,9 @@ class Product
             // if (is_object($av)) {
                 // $cnt = $db->GetOne("SELECT COUNT(avID) FROM CommunityStoreProductAttributeValues WHERE avID=?", $av->getAttributeValueID());
             // }
-            $newAv = StoreProductValue::getByID($newAvID);
+            if(!$isNew){
+              $newAv = StoreProductValue::getByID($newAvID);
+            }
             //create new attrib value in AttributeValues table first if there is no spav set for product
             if ((!is_object($newAv))) {
               //adds new av and assign as current av

--- a/src/CommunityStore/Product/ProductList.php
+++ b/src/CommunityStore/Product/ProductList.php
@@ -322,12 +322,15 @@ class ProductList extends AttributedItemList
             $rangePIDs = call_user_func_array('array_intersect',$temp);
             if(!empty($validPIDs)) $validPIDs = array_intersect($validPIDs, $rangePIDs);
         }
-        if($this->attributeSearch && $this->attributeRange){
-          $query->andWhere('p.pID in ('. implode(',', $validPIDs).')');
-        }else if($this->attributeSearch){
-          $query->orWhere('p.pID in ('. implode(',', $validPIDs).')');
-        }else if($this->attributeRange){
-          $query->andWhere('p.pID in ('. implode(',', $rangePIDs).')');
+        
+        if(!empty($validPIDs)){
+          if($this->attributeSearch && $this->attributeRange){
+            $query->andWhere('p.pID in ('. implode(',', $validPIDs).')');
+          }else if($this->attributeSearch){
+            $query->orWhere('p.pID in ('. implode(',', $validPIDs).')');
+          }else if($this->attributeRange){
+            $query->andWhere('p.pID in ('. implode(',', $rangePIDs).')');
+          }
         }
 
         return $query;

--- a/src/CommunityStore/Product/ProductList.php
+++ b/src/CommunityStore/Product/ProductList.php
@@ -6,6 +6,7 @@ use Concrete\Core\Search\ItemList\Database\AttributedItemList;
 use Pagerfanta\Adapter\DoctrineDbalAdapter;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product as StoreProduct;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Report\ProductReport as StoreProductReport;
+use Concrete\Package\CommunityStore\Src\Attribute\Key\StoreProductKey;
 
 class ProductList extends AttributedItemList
 {
@@ -95,7 +96,45 @@ class ProductList extends AttributedItemList
     {
         $this->search = $search;
     }
+    public function setGroupSearch($search)
+    {
+        $this->groupSearch = $search;
+    }
+    public function setAttributeSearch($search)
+    {
+        $this->attributeSearch = $search;
+    }
 
+    public function setMinPrice($price){
+        $this->minPrice = $price;
+    }
+    public function setMaxPrice($price){
+        $this->maxPrice = $price;
+    }
+
+    public function setMinWidth($width){
+        $this->minWidth = $width;
+    }
+    public function setMaxWidth($width){
+        $this->maxWidth = $width;
+    }
+
+    public function setMinHeight($height){
+        $this->minHeight = $height;
+    }
+    public function setMaxHeight($height){
+        $this->maxHeight = $height;
+    }
+    public function setMinLength($length){
+        $this->minLength = $length;
+    }
+    public function setMaxLength($length){
+        $this->maxLength = $length;
+    }
+    public function setAttributeVals($attributes)
+    {
+        $this->attributeVals = $attributes;
+    }
     public function finalizeQuery(\Doctrine\DBAL\Query\QueryBuilder $query)
     {
         $paramcount = 0;
@@ -199,10 +238,67 @@ class ProductList extends AttributedItemList
 
         $query->groupBy('p.pID');
 
-        if ($this->search) {
-            $query->andWhere('pName like ?')->setParameter($paramcount++, '%'. $this->search. '%');
+        //for price range filter
+        if($this->minPrice){
+          $query->andWhere('pPrice >= ? OR pSalePrice >= ?')->setParameter($paramcount++,$this->minPrice)->setParameter($paramcount++,$this->minPrice);
+        }
+        if($this->maxPrice){
+          $query->andWhere('pPrice <= ? OR pSalePrice <= ?')->setParameter($paramcount++,$this->maxPrice)->setParameter($paramcount++,$this->maxPrice);
+        }
+        //for width filter
+        if($this->minWidth){
+          $query->andWhere('pWidth >= ?')->setParameter($paramcount++,$this->minWidth);
+        }
+        if($this->maxWidth){
+          $query->andWhere('pWidth <= ?')->setParameter($paramcount++,$this->maxWidth);
+        }
+        //for height filter
+        if($this->minHeight){
+          $query->andWhere('pHeight >= ?')->setParameter($paramcount++,$this->minHeight);
+        }
+        if($this->maxHeight){
+          $query->andWhere('pHeight <= ?')->setParameter($paramcount++,$this->maxHeight);
         }
 
+        //for length filter
+        if($this->minLength){
+          $query->andWhere('pLength >= ?')->setParameter($paramcount++,$this->minLength);
+        }
+        if($this->maxLength){
+          $query->andWhere('pLength <= ?')->setParameter($paramcount++,$this->maxLength);
+        }
+
+
+
+        if ($this->search) {
+            $query->andWhere('pName like ? OR pDesc like ? OR pSKU like ?')->setParameter($paramcount++, '%'. $this->search. '%')->setParameter($paramcount++, '%'. $this->search. '%')->setParameter($paramcount++, '%'. $this->search. '%');
+        }
+        if($this->groupSearch){
+          //search through groupNames
+            $query->leftJoin('p', 'CommunityStoreProductGroups', 'pg', 'p.pID = pg.pID');
+            $query->leftJoin('pg', 'CommunityStoreGroups', 'g', 'pg.gID = g.gID');
+            $query->orWhere('g.groupName like ?')->setParameter($paramcount++, '%'. $this->groupSearch. '%');
+        }
+        //attributeVals filter
+        if (!empty($this->attributeVals)) {
+          $aks = array();
+          $avs = array();
+          foreach($this->attributeVals as $ak => $av){
+            $aks[] = $ak;
+            foreach($av as $avID){
+              $avs[] = $avID;
+            }
+          }
+          $query->leftJoin('p', 'CommunityStoreProductAttributeValues', 'av', 'p.pID = av.pID');
+          $query->andWhere('av.akID in('. implode(',', $aks) .') and av.avID in('. implode(',', $avs).')');
+
+        }
+        if($this->attributeSearch){
+            //search attributes
+            $validPIDs = StoreProductKey::filterAttributeValuesByKeyword($this->attributeSearch);
+            if(!empty($validPIDs)) $query->orWhere('p.pID in ('. implode(',', $validPIDs).')');
+
+        }
         return $query;
     }
 


### PR DESCRIPTION
Product filter and search includes filtering through categories, attributes, dimensions and keywords. This branch is different from filter-search branch as this no longer includes the import function. Some updates(compared to filter-search branch) include: 
Bug fix on show/hide filter
Show/hide filter is now only visible on smaller devices (<768)
Bug fix on product duplication (due to attribute assignment)
Use the select2 from c5 core
Range sliders steps 5 times (so when sliding or clicking through mobile it traverses 5 times only)
Rebase to latest commit (2f864ec)