### PR TITLE
Autonav breadcrumb template, for product category breadcrumbs

### DIFF
--- a/blocks/autonav/templates/product_breadcrumb.php
+++ b/blocks/autonav/templates/product_breadcrumb.php
@@ -1,0 +1,37 @@
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+
+$c = Page::getCurrentPage();
+$product = \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product::getByCollectionID($c->getCollectionID());
+
+if ($product) {
+    $locations = $product->getLocations();
+
+    if ($locations[0]) {
+        $first_location = $locations[0];
+        $controller->cID = $first_location->getCollectionID();
+
+
+        $navItems = $controller->getNavItems(true); // Ignore exclude from nav
+
+        if (count($navItems) > 0) {
+
+            echo '<nav role="navigation" aria-label="breadcrumb">'; //opens the top-level menu
+            echo '<ol class="breadcrumb">';
+
+            foreach ($navItems as $ni) {
+                if ($ni->isCurrent) {
+                    echo '<li class="active">' . $ni->name . '</li>';
+                } else {
+                    echo '<li><a href="' . $ni->url . '" target="' . $ni->target . '">' . $ni->name . '</a></li>';
+                }
+            }
+
+            echo '</ol>';
+            echo '</nav>'; //closes the top-level menu
+
+        } else if (is_object($c) && $c->isEditMode()) { ?>
+            <div class="ccm-edit-mode-disabled-item"><?php echo t('Empty Auto-Nav Block.') ?></div>
+        <?php }
+    }
+
+}


### PR DESCRIPTION
Adds a handy autonav template, for use when the autonav is displaying breadcrumbs - this version will look at the first category for a product and use _that_ as the basis for forming the breadcrumb trail