### PR TITLE
Added showName Display Option

### DIFF
--- a/blocks/community_product_list/add.php
+++ b/blocks/community_product_list/add.php
@@ -1,3 +1,3 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
-$this->inc('form.php', array('showAddToCart'=>true,'showPageLink'=>true,'showDescription'=>true, 'showPrice'=>true));
+$this->inc('form.php', array('showAddToCart'=>true,'showPageLink'=>true,'showDescription'=>true, 'showPrice'=>true, 'showName'=>true));

--- a/blocks/community_product_list/controller.php
+++ b/blocks/community_product_list/controller.php
@@ -157,6 +157,7 @@ class Controller extends BlockController
         $args['showDescription'] = isset($args['showDescription']) ? 1 : 0;
         $args['showQuickViewLink'] = isset($args['showQuickViewLink']) ? 1 : 0;
         $args['showPageLink'] = isset($args['showPageLink']) ? 1 : 0;
+        $args['showName'] = isset($args['showName']) ? 1 : 0;
         $args['showPrice'] = isset($args['showPrice']) ? 1 : 0;
         $args['showAddToCart'] = isset($args['showAddToCart']) ? 1 : 0;
         $args['showLink'] = isset($args['showLink']) ? 1 : 0;

--- a/blocks/community_product_list/db.xml
+++ b/blocks/community_product_list/db.xml
@@ -21,6 +21,7 @@
 		<field name="showFeatured" type="boolean"></field>
 		<field name="showSale" type="boolean"></field>
 		<field name="showDescription" type="boolean"></field>
+		<field name="showName" type="boolean"><default value="1"/></field>
 		<field name="showPrice" type="boolean"><default value="1"/></field>
 		<field name="showQuickViewLink" type="boolean"></field>
 		<field name="showPageLink" type="boolean"><default value="1"/></field>

--- a/blocks/community_product_list/form.php
+++ b/blocks/community_product_list/form.php
@@ -125,6 +125,12 @@
             </div>
             <div class="form-group checkbox">
                 <label>
+                    <?= $form->checkbox('showName', 1, $showName); ?>
+                    <?= t('Display Name') ?>
+                </label>
+            </div>
+            <div class="form-group checkbox">
+                <label>
                     <?= $form->checkbox('showPrice', 1, $showPrice); ?>
                     <?= t('Display Price') ?>
                 </label>

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -48,7 +48,9 @@ if($products){
     
         <div class="store-product-list-item <?= $columnClass; ?> <?= $activeclass; ?>">
             <form   id="store-form-add-to-cart-list-<?= $product->getID()?>">
+		<?php if ($showName) { ?>
                 <h2 class="store-product-list-name"><?= $product->getName()?></h2>
+		<?php } ?>
                 <?php 
                     $imgObj = $product->getImageObj();
                     if(is_object($imgObj)){


### PR DESCRIPTION
I discovered Product Name always show in Product List. This pull add the option "showName" to choose if Display or not the Name inside H2 tag.

I doubt if use a hideName attribute instead of showName, but I suppose if it default true in add.php could be enough for backward compatibility.

Tell me if you agree.

I attach screen with a really case where title of product not wanted. 

HTH
Alessandro - Lota

![showname](https://cloud.githubusercontent.com/assets/956392/20708652/46131d3c-b631-11e6-90f4-aef205af36a4.jpg)
