### PR TITLE
Fix queries so that they don't fail when MySQL run in strict mode

### DIFF
--- a/src/CommunityStore/Discount/DiscountRuleList.php
+++ b/src/CommunityStore/Discount/DiscountRuleList.php
@@ -68,7 +68,7 @@ class DiscountRuleList extends ItemList
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->select('count(distinct r.drID)')->setMaxResults(1);
+            $query->resetQueryParts(array('groupBy', 'orderBy'))->select('count(distinct r.drID)')->setMaxResults(1);
         });
         $pagination = new Pagination($this, $adapter);
 
@@ -79,6 +79,6 @@ class DiscountRuleList extends ItemList
     {
         $query = $this->deliverQueryObject();
 
-        return $query->select('count(distinct r.drID)')->setMaxResults(1)->execute()->fetchColumn();
+        return $query->resetQueryParts(array('groupBy', 'orderBy'))->select('count(distinct r.drID)')->setMaxResults(1)->execute()->fetchColumn();
     }
 }

--- a/src/CommunityStore/Order/OrderList.php
+++ b/src/CommunityStore/Order/OrderList.php
@@ -140,7 +140,7 @@ class OrderList  extends AttributedItemList
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->select('count(distinct o.oID)')->setMaxResults(1);
+            $query->resetQueryParts(array('groupBy', 'orderBy'))->select('count(distinct o.oID)')->setMaxResults(1);
         });
         $pagination = new Pagination($this, $adapter);
 
@@ -151,7 +151,7 @@ class OrderList  extends AttributedItemList
     {
         $query = $this->deliverQueryObject();
 
-        return $query->select('count(distinct o.oID)')->setMaxResults(1)->execute()->fetchColumn();
+        return $query->resetQueryParts(array('groupBy', 'orderBy'))->select('count(distinct o.oID)')->setMaxResults(1)->execute()->fetchColumn();
     }
 
     public static function getDateOfFirstOrder()

--- a/src/CommunityStore/Product/ProductList.php
+++ b/src/CommunityStore/Product/ProductList.php
@@ -218,8 +218,7 @@ class ProductList extends AttributedItemList
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->select('count(distinct p.pID) c ');
-            $query->groupBy('null');
+            $query->resetQueryParts(array('groupBy', 'orderBy'))->select('count(distinct p.pID) c ');
             $query->having('1 = 1');
         });
         $pagination = new Pagination($this, $adapter);
@@ -231,6 +230,6 @@ class ProductList extends AttributedItemList
     {
         $query = $this->deliverQueryObject();
 
-        return $query->select('count(distinct p.pID)')->setMaxResults(1)->execute()->fetchColumn();
+        return $query->resetQueryParts(array('groupBy', 'orderBy'))->select('count(distinct p.pID)')->setMaxResults(1)->execute()->fetchColumn();
     }
 }


### PR DESCRIPTION
If MySQL is running in strict mode (default of latest MySQL versions), we have query errors like this one:
```
An exception occurred while executing
'SELECT count(distinct p.pID) c
FROM CommunityStoreProducts p
GROUP BY null HAVING 1 = 1
ORDER BY pDateAdded desc':
SQLSTATE[42000]: Syntax error or access violation: 1055
Expression #1 of ORDER BY clause is not in GROUP BY clause
and contains nonaggregated column 'pDateAdded' which is not functionally dependent on columns
in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```
Let's fix this (exactly like I fixed it for the core: see https://github.com/concrete5/concrete5/pull/4721