### PR TITLE
Enhance states field replacement function

### DIFF
--- a/js/communityStore.js
+++ b/js/communityStore.js
@@ -270,16 +270,18 @@ var communityStore = {
     updateBillingStates: function (load) {
         var countryCode = $("#store-checkout-billing-country").val();
         var selectedState;
+        var classList = $("#store-checkout-billing-state").attr('class').toString();
+        var dataList = JSON.stringify($("#store-checkout-billing-state").data());
         if (load) {
             selectedState = $("#store-checkout-saved-billing-state").val();
         } else {
             selectedState = '';
         }
-
+        
         $.ajax({
             url: CHECKOUTURL + "/getstates",
             type: 'post',
-            data: {country: countryCode, selectedState: selectedState, type: "billing"},
+            data: {country: countryCode, selectedState: selectedState, type: "billing", class: classList, data: dataList},
             success: function (states) {
                 $("#store-checkout-billing-state").replaceWith(states);
             }

--- a/src/CommunityStore/Utilities/States.php
+++ b/src/CommunityStore/Utilities/States.php
@@ -13,12 +13,20 @@ class States extends Controller
         $countryCode = $_POST['country'];
         $selectedState = $_POST['selectedState'];
         $type = $_POST['type'];
+        $class = empty($_POST['class']) ? 'form-control' : $_POST['class'];
+        $dataList = Core::make('helper/json')->decode($_POST['data']);
+        $data = '';
+        if (count($dataList)) {
+            foreach ($dataList as $name => $value) {
+                $data .= ' data-' . $name . '="' . $value . '"';
+            }
+        }
         $list = Core::make('helper/lists/states_provinces')->getStateProvinceArray($countryCode);
         if ($list) {
             if ($type == "tax") {
-                echo "<select name='taxState' id='taxState' class='form-control'>";
+                echo "<select name='taxState' id='taxState' class='{$class}'{$data}>";
             } else {
-                echo "<select required='required' name='store-checkout-{$type}-state' id='store-checkout-{$type}-state' ccm-passed-value='' class='form-control'>";
+                echo "<select required='required' name='store-checkout-{$type}-state' id='store-checkout-{$type}-state' ccm-passed-value='' class='{$class}'{$data}>";
             }
             echo '<option value=""></option>';
 
@@ -32,9 +40,9 @@ class States extends Controller
             echo "<select>";
         } else {
             if ($type == "tax") {
-                echo "<input type='text' name='taxState' id='taxState' class='form-control'>";
+                echo "<input type='text' name='taxState' id='taxState' class='{$class}'{$data}>";
             } else {
-                echo "<input type='text' name='store-checkout-{$type}-state' id='store-checkout-{$type}-state' value='{$selectedState}' class='form-control' placeholder='".t('State / Province')."'>";
+                echo "<input type='text' name='store-checkout-{$type}-state' id='store-checkout-{$type}-state' value='{$selectedState}' class='{$class}'{$data} placeholder='".t('State / Province')."'>";
             }
         }
     }


### PR DESCRIPTION
Keep custom classes and data-* attributes.

When the "States" field is replaced all custom classes and data-*
attributes are lost.

It's a problem for custom styling and js interaction.

For instance, if I use a class to size my input, it is removed and the
sizing is not respected anymore.