### PR TITLE
Shipping fields on order

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -16,7 +16,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '5.7.5';
-    protected $pkgVersion = '1.0.6';
+    protected $pkgVersion = '1.0.7';
 
     public function getPackageDescription()
     {

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -228,12 +228,29 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
             <strong><?= t("Shipping Method") ?>: </strong><?= $order->getShippingMethodName() ?>
         </p>
 
+
+
+        <?php
+        $trackingURL = $order->getTrackingURL();
+        $trackingCode = $order->getTrackingCode();
+        $carrier = $order->getCarrier();
+
+        if ($carrier) { ?>
+            <p><strong><?= t("Carrier") ?>: </strong><?= $carrier ?></p>
+        <?php }
+
+        if ($trackingCode) { ?>
+            <p><strong><?= t("Tracking Code") ?>: </strong><?= $trackingCode ?> </p>
+        <?php }
+
+        if ($trackingURL) { ?>
+        <p><a target="_blank" href="<?= $trackingURL; ?>"><?= t('View shipment tracking');?></a></p>
+        <?php } ?>
+
         <?php
         $shippingInstructions = $order->getShippingInstructions();
         if ($shippingInstructions) { ?>
-            <p>
-                <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?>
-            </p>
+            <p><strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?></p>
         <?php } ?>
 
     <?php } ?>

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -60,6 +60,12 @@ class Order
     /** @Column(type="text",nullable=true) */
     protected $sQuoteID;
 
+    /** @Column(type="text",nullable=true) */
+    protected $sTrackingID;
+
+    /** @Column(type="text",nullable=true) */
+    protected $sTrackingURL;
+
     /** @Column(type="decimal", precision=10, scale=2) * */
     protected $oShippingTotal;
 
@@ -147,8 +153,28 @@ class Order
         $this->sInstructions = $sInstructions;
     }
 
-    public function setShippingQuoteID($quoteID) {
+    public function setShippingQuoteID($quoteID)
+    {
         $this->sQuoteID = $quoteID;
+    }
+
+    public function getShippingTrackingID(){
+        return $this->sTrackingID;
+    }
+
+    public function setShippingTrackingID($sTrackingID)
+    {
+        $this->sTrackingID = $sTrackingID;
+    }
+
+    public function getShippingTrackingURL()
+    {
+        return $this->sTrackingURL;
+    }
+
+    public function setShippingTrackingURL($sTrackingURL)
+    {
+        $this->sTrackingURL = $sTrackingURL;
     }
 
     public function setShippingTotal($shippingTotal)

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -58,10 +58,19 @@ class Order
     protected $sInstructions;
 
     /** @Column(type="text",nullable=true) */
-    protected $sQuoteID;
+    protected $sShipmentID;
+
+    /** @Column(type="text",nullable=true) */
+    protected $sRateID;
+
+    /** @Column(type="text",nullable=true) */
+    protected $sCarrier;
 
     /** @Column(type="text",nullable=true) */
     protected $sTrackingID;
+
+    /** @Column(type="text",nullable=true) */
+    protected $sTrackingCode;
 
     /** @Column(type="text",nullable=true) */
     protected $sTrackingURL;
@@ -153,26 +162,61 @@ class Order
         $this->sInstructions = $sInstructions;
     }
 
-    public function setShippingQuoteID($quoteID)
+    public function setShipmentID($shipmentID)
     {
-        $this->sQuoteID = $quoteID;
+        $this->sShipmentID = $shipmentID;
     }
 
-    public function getShippingTrackingID(){
+    public function getShipmentID(){
+        return $this->sShipmentID;
+    }
+
+    public function getRateID()
+    {
+        return $this->sRateID;
+    }
+
+    public function setRateID($sRateID)
+    {
+        $this->sRateID = $sRateID;
+    }
+
+    public function getCarrier()
+    {
+        return $this->sCarrier;
+    }
+
+    public function setCarrier($sCarrier)
+    {
+        $this->sCarrier = $sCarrier;
+    }
+
+    public function getTrackingID()
+    {
         return $this->sTrackingID;
     }
 
-    public function setShippingTrackingID($sTrackingID)
+    public function setTrackingID($sTrackingID)
     {
         $this->sTrackingID = $sTrackingID;
     }
 
-    public function getShippingTrackingURL()
+    public function getTrackingCode()
+    {
+        return $this->sTrackingCode;
+    }
+
+    public function setTrackingCode($sTrackingCode)
+    {
+        $this->sTrackingCode = $sTrackingCode;
+    }
+
+    public function getTrackingURL()
     {
         return $this->sTrackingURL;
     }
 
-    public function setShippingTrackingURL($sTrackingURL)
+    public function setTrackingURL($sTrackingURL)
     {
         $this->sTrackingURL = $sTrackingURL;
     }
@@ -431,7 +475,8 @@ class Order
         $customer = new StoreCustomer();
         $now = new \DateTime();
         $smName = StoreShippingMethod::getActiveShippingLabel();
-        $sQuoteID = StoreShippingMethod::getActiveShippingQuoteID();
+        $sShipmentID = StoreShippingMethod::getActiveShipmentID();
+        $sRateID = StoreShippingMethod::getActiveRateID();
         $sInstructions = StoreCart::getShippingInstructions();
         $totals = StoreCalculator::getTotals();
         StoreCart::getShippingInstructions('');
@@ -470,7 +515,8 @@ class Order
         $order->setPaymentMethodName($pmDisplayName ? $pmDisplayName : $pmName);
         $order->setPaymentMethodID($pm->getID());
         $order->setShippingMethodName($smName);
-        $order->setShippingQuoteID($sQuoteID);
+        $order->setShipmentID($sShipmentID);
+        $order->setRateID($sRateID);
         $order->setShippingInstructions($sInstructions);
         $order->setShippingTotal($shippingTotal);
         $order->setTaxTotal($taxTotal);

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -57,6 +57,9 @@ class Order
     /** @Column(type="text",nullable=true) */
     protected $sInstructions;
 
+    /** @Column(type="text",nullable=true) */
+    protected $sQuoteID;
+
     /** @Column(type="decimal", precision=10, scale=2) * */
     protected $oShippingTotal;
 
@@ -142,6 +145,10 @@ class Order
     public function setShippingInstructions($sInstructions)
     {
         $this->sInstructions = $sInstructions;
+    }
+
+    public function setShippingQuoteID($quoteID) {
+        $this->sQuoteID = $quoteID;
     }
 
     public function setShippingTotal($shippingTotal)
@@ -285,6 +292,10 @@ class Order
         return $this->sInstructions;
     }
 
+    public function getShippingQuoteID() {
+        return $this->sQuoteID;
+    }
+
     public function getShippingTotal()
     {
         return $this->oShippingTotal;
@@ -394,6 +405,7 @@ class Order
         $customer = new StoreCustomer();
         $now = new \DateTime();
         $smName = StoreShippingMethod::getActiveShippingLabel();
+        $sQuoteID = StoreShippingMethod::getActiveShippingQuoteID();
         $sInstructions = StoreCart::getShippingInstructions();
         $totals = StoreCalculator::getTotals();
         StoreCart::getShippingInstructions('');
@@ -432,6 +444,7 @@ class Order
         $order->setPaymentMethodName($pmDisplayName ? $pmDisplayName : $pmName);
         $order->setPaymentMethodID($pm->getID());
         $order->setShippingMethodName($smName);
+        $order->setShippingQuoteID($sQuoteID);
         $order->setShippingInstructions($sInstructions);
         $order->setShippingTotal($shippingTotal);
         $order->setTaxTotal($taxTotal);

--- a/src/CommunityStore/Order/OrderList.php
+++ b/src/CommunityStore/Order/OrderList.php
@@ -87,6 +87,14 @@ class OrderList  extends AttributedItemList
             }
         }
 
+        if (isset($this->shippable)) {
+            if ($this->shippable) {
+                $this->query->andWhere('o.smName <> ""');
+            } else {
+                $this->query->andWhere('o.smName = ""');
+            }
+        }
+
         if (isset($this->refunded)) {
             if ($this->refunded) {
                 $this->query->andWhere('o.oRefunded is not null');
@@ -156,6 +164,10 @@ class OrderList  extends AttributedItemList
     public function setRefunded($bool)
     {
         $this->refunded = $bool;
+    }
+
+    public function setIsShippable($bool){
+        $this->shippable = $bool;
     }
 
     public function getResult($queryRow)

--- a/src/CommunityStore/Shipping/Method/ShippingMethod.php
+++ b/src/CommunityStore/Shipping/Method/ShippingMethod.php
@@ -258,17 +258,30 @@ class ShippingMethod
        return '';
     }
 
-    public static function getActiveShippingQuoteID() {
+    public static function getActiveShipmentID() {
         $activeShippingMethod = self::getActiveShippingMethod();
 
         if ($activeShippingMethod) {
             $currentOffer = $activeShippingMethod->getCurrentOffer();
             if ($currentOffer) {
-                return $currentOffer->getQuoteID();
+                return $currentOffer->getShipmentID();
             }
         }
 
        return '';
+    }
+
+    public static function getActiveRateID() {
+        $activeShippingMethod = self::getActiveShippingMethod();
+
+        if ($activeShippingMethod) {
+            $currentOffer = $activeShippingMethod->getCurrentOffer();
+            if ($currentOffer) {
+                return $currentOffer->getRateID();
+            }
+        }
+
+        return '';
     }
 
     public function getPackageHandle() {

--- a/src/CommunityStore/Shipping/Method/ShippingMethod.php
+++ b/src/CommunityStore/Shipping/Method/ShippingMethod.php
@@ -258,6 +258,19 @@ class ShippingMethod
        return '';
     }
 
+    public static function getActiveShippingQuoteID() {
+        $activeShippingMethod = self::getActiveShippingMethod();
+
+        if ($activeShippingMethod) {
+            $currentOffer = $activeShippingMethod->getCurrentOffer();
+            if ($currentOffer) {
+                return $currentOffer->getQuoteID();
+            }
+        }
+
+       return '';
+    }
+
     public function getPackageHandle() {
         return Package::getByID($this->getShippingMethodType()->getPackageID())->getPackageHandle();
     }

--- a/src/CommunityStore/Shipping/Method/ShippingMethodOffer.php
+++ b/src/CommunityStore/Shipping/Method/ShippingMethodOffer.php
@@ -10,7 +10,8 @@ class ShippingMethodOffer
     private $offerLabel;
     private $offerDetails;
     private $rate;
-    private $quoteID;
+    private $shipmentID;
+    private $rateID;
 
     /**
      * @return mixed
@@ -118,29 +119,29 @@ class ShippingMethodOffer
         return max(($this->rate * $percentage) - $deduct, 0);
     }
 
-    /**
-     * @param mixed $rate
-     */
     public function setRate($rate)
     {
         $this->rate = $rate;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getQuoteID()
+    public function getShipmentID()
     {
-        return $this->quoteID;
+        return $this->shipmentID;
     }
 
-    /**
-     * @param mixed $quoteID
-     */
-    public function setQuoteID($quoteID)
+    public function setShipmentID($shipmentID)
     {
-        $this->quoteID = $quoteID;
+        $this->shipmentID = $shipmentID;
     }
 
+    public function getRateID()
+    {
+        return $this->rateID;
+    }
+
+    public function setRateID($rateID)
+    {
+        $this->rateID = $rateID;
+    }
 
 }

--- a/src/CommunityStore/Shipping/Method/ShippingMethodOffer.php
+++ b/src/CommunityStore/Shipping/Method/ShippingMethodOffer.php
@@ -10,6 +10,7 @@ class ShippingMethodOffer
     private $offerLabel;
     private $offerDetails;
     private $rate;
+    private $quoteID;
 
     /**
      * @return mixed
@@ -125,6 +126,21 @@ class ShippingMethodOffer
         $this->rate = $rate;
     }
 
+    /**
+     * @return mixed
+     */
+    public function getQuoteID()
+    {
+        return $this->quoteID;
+    }
+
+    /**
+     * @param mixed $quoteID
+     */
+    public function setQuoteID($quoteID)
+    {
+        $this->quoteID = $quoteID;
+    }
 
 
 }


### PR DESCRIPTION
This adds a bunch of fields on an order to support shipping and tracking (specifically to support easypost.com).

When a Shipping URL is stored against an order it appears on the order summary within the dashboard as a clickable link.