### PR TITLE
New isProductInGroup function could be useful

### DIFF
--- a/src/CommunityStore/Product/ProductGroup.php
+++ b/src/CommunityStore/Product/ProductGroup.php
@@ -102,6 +102,20 @@ class ProductGroup
         return $groups;
     }
 
+    public static function isProductInGroup(StoreProduct $product, StoreGroup $group)
+    {
+        $em = \ORM::entityManager();
+        $gID = $group->getGroupID();
+        
+        $productGroup = $em->getRepository(get_class())->findBy(array('pID' => $product->getID(), 'gID' => $gID));
+        if (count($productGroup)) {
+            return true;
+        }
+
+
+        return false;
+    }
+    
     public static function getGroupIDsForProduct(StoreProduct $product)
     {
         $groups = self::getGroupsForProduct($product);


### PR DESCRIPTION
I needed to check if a product was in a specific group and the only way to do it was to get all groups for a product and loop through them.

This function is more convenient and saves us a loop.

@Ryan if you think it can be useful, please add.