### PR TITLE
[Request] Add CSV support in report sales.

### DIFF
--- a/controllers/single_page/dashboard/store/reports/sales.php
+++ b/controllers/single_page/dashboard/store/reports/sales.php
@@ -47,12 +47,98 @@ class Sales extends DashboardPageController
         $this->requireAsset('css', 'communityStoreDashboard');
      
     }
-    //TODO
+
     public function export()
     {
         $from = $this->get('fromDate');
         $to = $this->get('toDate');
+
+        //TODO maybe get all existing orders if needed
+        // set to and from 
+        if($to == '' || $to == null)
+        {
+            $to = date('Y-m-d'); // set to today
+        }
+        if($from == '' || $from == null)
+        {
+            $from = strtotime('-7 day',$to); // set from a week ago
+        }
+
+        // get orders and set the from and to
+        $orders = new StoreOrderList();
+        $orders->setFromDate($from);
+        $orders->setToDate($to);
+        //$orders->setItemsPerPage(10);
+        $orders->setPaid(true);
+        $orders->setCancelled(false);
+
+        // exporting 
+        $export = array();
+        // get all order requests
+        $orders = $orders->getResults();
         
+        foreach($orders as $o)
+        {
+            // get tax info for our export data
+            $tax = $o->getTaxTotal();
+            $includedTax = $o->getIncludedTaxTotal();
+            if ($tax) {
+                $orderTax = Price::format($tax);
+            } elseif ($includedTax) {
+                $orderTax = Price::format($includedTax);
+            }
+            // getOrderDate returns DateTime need to format it as string
+            $date = $o->getOrderDate();
+            // set up our export array
+            $export[] = array(
+                'Order #'=>$o->getOrderID(),
+                'Date'=>$date->format('Y-m-d H:i:s'),
+                'Products'=>$o->getSubTotal(),
+                'Shipping'=>$o->getShippingTotal(),
+                'Tax'=>$orderTax,
+                'Total'=>$o->getTotal()
+            );
+        }
+
+        // if we have something to export
+        if(count($export) > 0)
+        {
+            // timings for cache disabling in headers and the file name
+            $now = gmdate("D, d M Y H:i:s");
+            $expire = gmdate("D, d M Y H:i:s",strtotime("+1 day"));
+            $filename = 'sale_report_'.date('Y-m-d').".csv";
+            
+            // disable caching
+            header("Expires: {$expire} GMT");
+            header("Cache-Control: max-age=0, no-cache, must-revalidate, proxy-revalidate");
+            header("Last-Modified: {$now} GMT");
+
+            // force download  
+            header("Content-Type: application/force-download");
+            header("Content-Type: application/octet-stream");
+            header("Content-Type: application/download");
+
+            // disposition / encoding on response body
+            header("Content-Disposition: attachment;filename={$filename}");
+            header("Content-Transfer-Encoding: binary");
+
+            // start our output buffer and write to output
+            ob_start();
+            $df = fopen('php://output','w');
+            // output our keys
+            fputcsv($df, array_keys(reset($export)));
+            // output our data
+            foreach($export as $row)
+            {
+                fputcsv($df,$row);
+            }
+            fclose($df);
+            // finally output our data
+            echo ob_get_clean();
+            die();
+        }
+        // redirect if no data to output
+        $this->redirect('/dashboard/store/reports/sales');
     }
     
 }

--- a/single_pages/dashboard/store/reports/sales.php
+++ b/single_pages/dashboard/store/reports/sales.php
@@ -203,7 +203,7 @@ $(function(){
 				<th><?= t("Shipping")?></th>
 				<th><?= t("Tax")?> <?= $extraTaxLable?></th>
 				<th><?= t("Total")?></th>
-				<!--<th><?= t("Export")?></th>-->
+				<th><?= t("Export")?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -212,7 +212,7 @@ $(function(){
 				<td><?=Price::format($ordersTotals['shippingTotal'])?></td>
 				<td><?=Price::format($ordersTotals[$taxValue])?></td>
 				<td><?=Price::format($ordersTotals['total'])?></td>
-				<!--<td><a href="<?=URL::to('/dashboard/store/reports/sales/export?fromDate='.$dateFrom.'&toDate='.$dateTo)?>" class="btn btn-default"><?= t('Export to CSV')?></a></td>-->
+				<td><a href="<?=URL::to('/dashboard/store/reports/sales/export?fromDate='.$dateFrom.'&toDate='.$dateTo)?>" class="btn btn-default"><?= t('Export to CSV')?></a></td>
 			</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
This adds CSV to the sale report screen while preventing caching of the csv file.

Creates an CSV of orders and downloads the file. If no orders are found it will just redirect back to the sales page. Filename and array structure can be changed later if needed. 

Is it worth adding a catch all if no to and from date is given? The button uses the queried dates but getting a complete history should be possible without any dates. In any case I defaulted it from a week ago when no to or from is given. 

Author: James Bishop (Heihachi) @Tooq Inc