### PR TITLE
Dealing with no decimal currencies like the Japanese Yen

### DIFF
--- a/src/CommunityStore/Utilities/Price.php
+++ b/src/CommunityStore/Utilities/Price.php
@@ -5,27 +5,65 @@ use Config;
 
 class Price
 {
+    public static function isZeroDecimalCurrency($currency)
+    {
+        $zeroDecimalCurrencies = [
+            'BIF',
+            'CLP',
+            'DJF',
+            'GNF',
+            'JPY',
+            'KMF',
+            'KRW',
+            'MGA',
+            'PYG',
+            'RWF',
+            'VND',
+            'VUV',
+            'XAF',
+            'XOF',
+            'XPF',
+        ];
+
+        return in_array($currency, $zeroDecimalCurrencies);
+    }
+
+    public static function getCurrencyMultiplier($currency)
+    {
+        return self::isZeroDecimalCurrency($currency) ? 1 : 100;
+    }
+
     public static function format($price)
     {
         $price = floatval($price);
         $symbol = Config::get('community_store.symbol');
         $wholeSep = Config::get('community_store.whole');
         $thousandSep = Config::get('community_store.thousand');
-        $price = $symbol . number_format($price, 2, $wholeSep, $thousandSep);
+        $currency = Config::get('community_store_stripe.currency');
+        $decimals = self::isZeroDecimalCurrency($currency) ? 0 : 2;
+        $price = $symbol . number_format($price, $decimals, $wholeSep, $thousandSep);
 
         return $price;
     }
+
     public static function formatFloat($price)
     {
-        $price = floatval($price);
-        $price = number_format($price, 2, ".", "");
+        $currency = Config::get('community_store_stripe.currency');
+        if (!self::isZeroDecimalCurrency($currency)) {
+            $price = floatval($price);
+            $price = number_format($price, 2, ".", "");
+        }
 
         return $price;
     }
 
     public static function formatInNumberOfCents($price)
     {
-        $price = number_format($price * 100, 0, "", "");
+        $currency = Config::get('community_store_stripe.currency');
+        if (!self::isZeroDecimalCurrency($currency)) {
+            $price = number_format($price * 100, 0, "", "");
+        }
+
         return $price;
     }
 


### PR DESCRIPTION
1 error for instance that was obvious was if I set the currency to Japanese Yen and set the decimal symbol to nothing and have a product with a price of 1000 JPY than I ended up paying 100000 JPY. Not good.

This only takes care of the front-end. The back-end deals with amounts differently and there were no decimal related errors. The only thing is that non-decimal currencies will always show with decimals but they'll always be zero so mathematically it's not a problem.

I am also modifying the Stripe plugin to take that into account and it will need these modifications to work.