### PR TITLE
Product list searching/filtering by attributes

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -16,7 +16,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '5.7.5';
-    protected $pkgVersion = '1.1.6.1';
+    protected $pkgVersion = '1.1.6.2';
 
     public function getPackageDescription()
     {
@@ -47,6 +47,7 @@ class Controller extends Package
         Installer::createDDFileset($pkg);
         Installer::installOrderStatuses($pkg);
         Installer::installDefaultTaxClass($pkg);
+        Installer::addProductSearchIndexTable($pkg);
     }
 
     public function install()

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -317,6 +317,8 @@ class Products extends DashboardPageController
                 // save related products
                 StoreProductRelated::addRelatedProducts($data, $product);
 
+				$product->reindex();
+
                 if($data['pID']){
                     $this->redirect('/dashboard/store/products/edit/' . $product->getID(), 'updated');
                 } else {

--- a/src/Attribute/Key/StoreProductKey.php
+++ b/src/Attribute/Key/StoreProductKey.php
@@ -22,6 +22,25 @@ class StoreProductKey extends Key
 		return 'CommunityStoreProductSearchIndexAttributes';
 	}
 
+	// required, because method does not exist in 5.8.
+	public function getIndexedSearchTable() {
+		return self::getDefaultIndexedSearchTable();
+	}
+
+	// required, because method does not exist in 5.8.
+	public function createIndexedSearchTable()
+	{
+		if ($this->getIndexedSearchTable() != false) {
+			$db = \Database::get();
+			$platform = $db->getDatabasePlatform();
+			$array[$this->getIndexedSearchTable()] = $this->searchIndexFieldDefinition;
+			$schema = \Concrete\Core\Database\Schema\Schema::loadFromArray($array, $db);
+			$queries = $schema->toSql($platform);
+			foreach ($queries as $query) {
+				$db->query($query);
+			}
+		}
+	}
 
     public static function getAttributes($pID, $method = 'getValue')
     {

--- a/src/Attribute/Key/StoreProductKey.php
+++ b/src/Attribute/Key/StoreProductKey.php
@@ -8,6 +8,21 @@ use Concrete\Core\Support\Facade\Application;
 
 class StoreProductKey extends Key
 {
+
+	protected $searchIndexFieldDefinition = array(
+		'columns' => array(
+			array('name' => 'pID', 'type' => 'integer', 'options' => array('unsigned' => true, 'default' => 0, 'notnull' => true)),
+		),
+		'primary' => array('pID'),
+	);
+
+
+	public static function getDefaultIndexedSearchTable()
+	{
+		return 'CommunityStoreProductSearchIndexAttributes';
+	}
+
+
     public static function getAttributes($pID, $method = 'getValue')
     {
         $app = Application::getFacadeApplication();

--- a/src/CommunityStore/Product/ProductList.php
+++ b/src/CommunityStore/Product/ProductList.php
@@ -215,6 +215,8 @@ class ProductList extends AttributedItemList
             $query->andWhere('pName like ?')->setParameter($paramcount++, '%'. $this->search. '%')->orWhere('pSKU like ?')->setParameter($paramcount++, '%'. $this->search. '%');
         }
 
+		$query->leftJoin('p', 'CommunityStoreProductSearchIndexAttributes', 'csi', 'p.pID = csi.pID');
+
         return $query;
     }
 

--- a/src/CommunityStore/Utilities/Installer.php
+++ b/src/CommunityStore/Utilities/Installer.php
@@ -25,6 +25,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as StorePa
 use Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethodType as StoreShippingMethodType;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderStatus\OrderStatus as StoreOrderStatus;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Tax\TaxClass as StoreTaxClass;
+use Concrete\Package\CommunityStore\Src\Attribute\Key\StoreProductKey;
 
 defined('C5_EXECUTE') or die(_("Access Denied."));
 
@@ -298,6 +299,11 @@ class Installer
         }
     }
 
+	public static function addProductSearchIndexTable($pkg){
+		$spk = new StoreProductKey();
+		$spk->createIndexedSearchTable();
+	}
+
     public static function createDDFileset($pkg)
     {
         //create fileset to place digital downloads
@@ -374,5 +380,6 @@ class Installer
         }
         Localization::clearCache();
         self::installUserAttributes($pkg);
+		Installer::addProductSearchIndexTable($pkg);
     }
 }


### PR DESCRIPTION
I wanted a list of products filtered by a particular attribute. Since the product list extends the item list, I was expecting the filterByAttribute method to work. It didn't. Instead an SQL error was thrown because the search field didn't exist. The pull request adds support for a product search index table, which uses the same mechanism that page/file/user attributes do., but with a separate table.