### PR TITLE
Wrong variable

### DIFF
--- a/src/CommunityStore/Cart/Cart.php
+++ b/src/CommunityStore/Cart/Cart.php
@@ -198,7 +198,7 @@ class Cart
                 } elseif (substr($name, 0, 2) == 'pt') {
                     $groupID = str_replace("pt", "", $name);
                 } elseif (substr($name, 0, 2) == 'pa') {
-                    $groupID = str_replace("pa", "", $groupID);
+                    $groupID = str_replace("pa", "", $name);
                 } elseif (substr($name, 0, 2) == 'ph') {
                     $groupID = str_replace("ph", "", $name);
                 } elseif (substr($name, 0, 2) == 'pc') {


### PR DESCRIPTION
Unless I'm greatly mistaken, you meant to strip 'pa' from the post name of Product Options of type textarea, generated in the product block type. This would strip 'pa' from `false`.