### PR TITLE
Optional Order Receipt

### DIFF
--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -601,6 +601,7 @@ class Order
 
         $pmID = $this->getPaymentMethodID();
 
+        $sendReceipt = false;
         if ($pmID) {
             $paymentMethodUsed = StorePaymentMethod::getByID($this->getPaymentMethodID());
 
@@ -609,6 +610,7 @@ class Order
                 if ($paymentMethodUsed->getMethodController()->markPaid()) {
                    $this->completePayment($sameRequest);
                 }
+                $sendReceipt = $this->getMethodController()->sendReceipt();
             }
         }
 
@@ -620,7 +622,9 @@ class Order
         Events::dispatch('on_community_store_order', $event);
 
         //receipt
-        $this->sendOrderReceipt();
+        if ($sendReceipt) {
+            $this->sendOrderReceipt();
+        }
 
         // notifications
         $this->sendNotifications();

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -601,7 +601,7 @@ class Order
 
         $pmID = $this->getPaymentMethodID();
 
-        $sendReceipt = false;
+        $sendReceipt = true;
         if ($pmID) {
             $paymentMethodUsed = StorePaymentMethod::getByID($this->getPaymentMethodID());
 

--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -280,6 +280,10 @@ class Method extends Controller
         return true;
     }
 
+    public function sendReceipt() {
+        return true;
+    }
+
     // method stub
     public function redirectForm() {
     }


### PR DESCRIPTION
I'd like to make sending the receipt on order completion optional, depending on the payment method.
This would be controlled by the method sendReceipt() in the payment method controller, and would default to true