### PR TITLE
Adding pID back in product sent to event

### DIFF
--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -494,7 +494,8 @@ class Product
             //if we know the pID, we're updating.
             $product = self::getByID($data['pID']);
             $originalProduct = clone $product;
-
+            $originalProduct->setID($data['pID']);
+		
             $product->setPageDescription($data['pDesc']);
             $newproduct = false;
             if ($data['pDateAdded_dt']) {


### PR DESCRIPTION
When saving an existing product a clone is first created. That clone is used in the product created event. However, it doesn't have a pID. This fix just gives it back its pID