### PR TITLE
Remove extra call to getShippingInstructions

### DIFF
--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -474,7 +474,6 @@ class Order
         $sRateID = StoreShippingMethod::getActiveRateID();
         $sInstructions = StoreCart::getShippingInstructions();
         $totals = StoreCalculator::getTotals();
-        StoreCart::getShippingInstructions('');
         $shippingTotal = $totals['shippingTotal'];
         $taxes = $totals['taxes'];
         $total = $totals['total'];


### PR DESCRIPTION
* Remove extra call to `StoreCart::getShippingInstructions()`

Is called two lines above and is not actually assigned to anything