### PR TITLE
Clean up keyword search term whitespace

### DIFF
--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -45,7 +45,7 @@ class Products extends DashboardPageController
 
 
         if ($this->get('keywords')) {
-            $products->setSearch($this->get('keywords'));
+            $products->setSearch(trim($this->get('keywords')));
         }
 
         $this->set('productList', $products);


### PR DESCRIPTION
* Clean up keyword search term whitespace

If keywords had trailing whitespace, which often happens with copy and
paste, the search would return false.