### PR TITLE
Fixes issus 337 Next button on Checkout in mobile is blocked by Cart …

### DIFF
--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -147,11 +147,11 @@ use \Concrete\Package\CommunityStore\Src\Attribute\Key\StoreOrderKey as StoreOrd
 
                             </div>
                         <?php } ?>
-
-                        <div class="store-checkout-form-group-buttons">
-                            <input type="submit" class="store-btn-next-pane btn btn-default pull-right" value="<?= t("Next") ?>">
+                        <div class="row">
+                            <div class="store-checkout-form-group-buttons col-md-12">
+                                <input type="submit" class="store-btn-next-pane btn btn-default pull-right" value="<?= t("Next") ?>">
+                            </div>
                         </div>
-
                     </div>
 
                     <div class="store-checkout-form-group-summary panel panel-default ">


### PR DESCRIPTION
…View Element.

This adds a div with class row around the Next button when entering billing info.
With out this row the pull-right was causing the next button to be float behind the cart view div on mobile layouts. This made the button not clickable. #337