### PR TITLE
added xss preventions

### DIFF
--- a/src/CommunityStore/Utilities/States.php
+++ b/src/CommunityStore/Utilities/States.php
@@ -8,11 +8,11 @@ class States extends Controller
 {
     public function getStateList()
     {
-        $countryCode = $_POST['country'];
-        $selectedState = $_POST['selectedState'];
-        $type = $_POST['type'];
-        $class = empty($_POST['class']) ? 'form-control' : $_POST['class'];
-        $dataList = Core::make('helper/json')->decode($_POST['data'], true);
+        $countryCode = htmlspecialchars($_POST['country']);
+        $selectedState = htmlspecialchars($_POST['selectedState']);
+        $type = htmlspecialchars($_POST['type']);
+        $class = empty(htmlspecialchars($_POST['class'])) ? 'form-control' : htmlspecialchars($_POST['class']);
+        $dataList = Core::make('helper/json')->decode(htmlspecialchars($_POST['data']), true);
         $data = '';
         if (is_array($dataList) && count($dataList)) {
             foreach ($dataList as $name => $value) {


### PR DESCRIPTION
Hi,
I found a Cross Site Scripting vulnerability inside src/CommunityStore/Utilities/States.php
By manipulating a specific POST-Request arbitrary html-tags can be embedded into the website.

Steps to reproduce this issue:
1. Install concrete5 according installation instructions
2. Login as administrator
3. Install concrete5-community-store according installation instructions
4. Create a new product under Dashboard -> Store -> Products
5. Add a new product with the button "Add product"
6. Fill in some random data remembering the name, e.g. testproduct and setting the active status
7. Save the product with the button "Add product"
8. Get your created product [URL]/concrete/index.php/products/testproduct
9. Add it to the cart and immediately proceed with the checkout
10. Now you should be on the site [URL]/concrete/index.php/checkout
11. This is where the vulnerability can be triggered

By manipulating the POST-Request
POST /concrete/index.php/checkout/getstates HTTP/1.1
country=US&selectedState=&type=billing&class=form-control&data=%7B%7D

and changing the POST parameters to something like
country=US&selectedState=&type=billing&class='style%3d"background-color:red"+onchange%3d"alert('XSS')%3b"+bla%3d'&data=%7B%7D

The content of the class variable gets injected into the website DOM.
When the site finished loading the State/Province selection should be red colored.
If you then select one item in the selection a popup with the text "XSS" should appear.

By wrapping the POST variables inside "src/CommunityStore/Utilities/States.php
" with htmlspecialchars() this vulnerability is prevented.

Please check the rest of the project-files and sanitize user's input data.
There might be more exploitable XSS vulnerabilities.
