### PR TITLE
Mnakalay v8 thumbnail types

### DIFF
--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -1,8 +1,7 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$defaultImageWidth = Config::get('community_store.defaultSingleProductImageWidth') ?: 720;
-$defaultImageHeight = Config::get('community_store.defaultSingleProductImageHeight') ?: 720;
+$communityStoreImageHelper = Core::make('cs/helper/image', ['single_product']);
 
 if (is_object($product) && $product->isActive()) {
     $options = $product->getOptions();
@@ -351,7 +350,7 @@ if (is_object($product) && $product->isActive()) {
                         <?php
                         $imgObj = $product->getImageObj();
                             if (is_object($imgObj)) {
-                                $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultImageWidth, $defaultImageHeight, false); ?>
+                                $thumb = $communityStoreImageHelper->getThumbnail($imgObj); ?>
                             <div class="store-product-primary-image ">
                                 <a itemprop="image" href="<?= $imgObj->getRelativePath(); ?>"
                                    title="<?= h($product->getName()); ?>"
@@ -368,9 +367,13 @@ if (is_object($product) && $product->isActive()) {
                                 $loop = 1;
                                 echo '<div class="store-product-additional-images clearfix no-gutter">';
 
+                                // This is only needed if no thumbnail type was defined or for some reason
+                                // we need to fallback on the legacy thumbnailer.
+                                $communityStoreImageHelper->setLegacyThumbnailCrop(true);
+
                                 foreach ($images as $secondaryImage) {
                                     if (is_object($secondaryImage)) {
-                                        $thumb = Core::make('helper/image')->getThumbnail($secondaryImage, $defaultImageWidth, $defaultImageHeight, true); ?>
+                                        $thumb = $communityStoreImageHelper->getThumbnail($secondaryImage); ?>
                                     <div class="store-product-additional-image col-md-6 col-sm-6"><a
                                                 href="<?= $secondaryImage->getRelativePath(); ?>"
                                                 title="<?= h($product->getName()); ?>"
@@ -413,6 +416,10 @@ if (is_object($product) && $product->isActive()) {
 
             <?php
                 $varationData = [];
+                            // This is only needed if no thumbnail type was defined or for some reason
+                            // we need to fallback on the legacy thumbnailer. We set it again because we set it to true above
+                            $communityStoreImageHelper->setLegacyThumbnailCrop(false);
+
                             foreach ($variationLookup as $key => $variation) {
                                 $product->setVariation($variation);
                                 $imgObj = $product->getImageObj();
@@ -420,7 +427,7 @@ if (is_object($product) && $product->isActive()) {
                                 $thumb = false;
 
                                 if ($imgObj) {
-                                    $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultImageWidth, $defaultImageHeight, false);
+                                    $thumb = $communityStoreImageHelper->getThumbnail($imgObj);
                                 }
 
                                 $varationData[$key] = [

--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -1,8 +1,8 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$defaultimagewidth = 720;
-$defaultimageheight = 720;
+$defaultImageWidth = 720;
+$defaultImageHeight = 720;
 
 if (is_object($product) && $product->isActive()) {
     $options = $product->getOptions();
@@ -245,10 +245,12 @@ if (is_object($product) && $product->isActive()) {
                                 ?>
                                 <div class="store-product-option-group form-group <?= $option->getHandle(); ?>">
                                     <label class="store-product-option-group-label"><?= $option->getName(); ?></label>
-                                    <?php if ($displayType != 'radio') { ?>
+                                    <?php if ('radio' != $displayType) {
+                                    ?>
                                     <select class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : ''; ?> form-control"
                                             name="po<?= $option->getID(); ?>">
-                                    <?php } ?>
+                                    <?php
+                                } ?>
                                         <?php
                                         $firstAvailableVariation = false;
                                 $variation = false;
@@ -267,21 +269,27 @@ if (is_object($product) && $product->isActive()) {
                                             $selected = 'selected="selected"';
                                         } ?>
 
-                                        <?php if ($displayType == 'radio') { ?>
+                                        <?php if ('radio' == $displayType) {
+                                            ?>
                                             <div class="radio">
-                                                <label><input type="radio" required class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : '' ?> "
-                                                        <?= $disabled .  ($selected ? 'checked' : ''); ?> name="po<?= $option->getID();?>" value="<?= $optionItem->getID(); ?>" /><?= h($optionItem->getName());?></label>
+                                                <label><input type="radio" required class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : ''; ?> "
+                                                        <?= $disabled . ($selected ? 'checked' : ''); ?> name="po<?= $option->getID(); ?>" value="<?= $optionItem->getID(); ?>" /><?= h($optionItem->getName()); ?></label>
                                             </div>
-                                        <?php } else { ?>
+                                        <?php
+                                        } else {
+                                            ?>
                                         <option <?= $disabled . ' ' . $selected; ?>value="<?= $optionItem->getID(); ?>"><?= $optionItem->getName() . $outOfStock; ?></option>
-                                        <?php } ?>
+                                        <?php
+                                        } ?>
 
                                         <?php
-                                        }
+                                    }
                                 } ?>
-                                     <?php if ($displayType != 'radio') { ?>
+                                     <?php if ('radio' != $displayType) {
+                                    ?>
                                     </select>
-                                    <?php } ?>
+                                    <?php
+                                } ?>
                                 </div>
                             <?php
                             } elseif ('text' == $optionType) {
@@ -343,7 +351,7 @@ if (is_object($product) && $product->isActive()) {
                         <?php
                         $imgObj = $product->getImageObj();
                             if (is_object($imgObj)) {
-                                $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultimagewidth, $defaultimageheight, false); ?>
+                                $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultImageWidth, $defaultImageHeight, false); ?>
                             <div class="store-product-primary-image ">
                                 <a itemprop="image" href="<?= $imgObj->getRelativePath(); ?>"
                                    title="<?= h($product->getName()); ?>"
@@ -360,11 +368,11 @@ if (is_object($product) && $product->isActive()) {
                                 $loop = 1;
                                 echo '<div class="store-product-additional-images clearfix no-gutter">';
 
-                                foreach ($images as $secondaryimage) {
-                                    if (is_object($secondaryimage)) {
-                                        $thumb = Core::make('helper/image')->getThumbnail($secondaryimage, $defaultimagewidth, $defaultimageheight, true); ?>
+                                foreach ($images as $secondaryImage) {
+                                    if (is_object($secondaryImage)) {
+                                        $thumb = Core::make('helper/image')->getThumbnail($secondaryImage, $defaultImageWidth, $defaultImageHeight, true); ?>
                                     <div class="store-product-additional-image col-md-6 col-sm-6"><a
-                                                href="<?= $secondaryimage->getRelativePath(); ?>"
+                                                href="<?= $secondaryImage->getRelativePath(); ?>"
                                                 title="<?= h($product->getName()); ?>"
                                                 class="store-product-thumb text-center center-block"><img
                                                     src="<?= $thumb->src; ?>"/></a></div>
@@ -404,7 +412,7 @@ if (is_object($product) && $product->isActive()) {
                             ?>
 
             <?php
-            $varationData = [];
+                $varationData = [];
                             foreach ($variationLookup as $key => $variation) {
                                 $product->setVariation($variation);
                                 $imgObj = $product->getImageObj();
@@ -412,20 +420,20 @@ if (is_object($product) && $product->isActive()) {
                                 $thumb = false;
 
                                 if ($imgObj) {
-                                    $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultimagewidth, $defaultimageheight, false);
+                                    $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultImageWidth, $defaultImageHeight, false);
                                 }
 
                                 $varationData[$key] = [
-                    'price' => $product->getFormattedOriginalPrice(),
-                    'saleprice' => $product->getFormattedSalePrice(),
-                    'available' => ($variation->isSellable()),
-                    'imageThumb' => $thumb ? $thumb->src : '',
-                    'image' => $imgObj ? $imgObj->getRelativePath() : '',
-                ];
+                        'price' => $product->getFormattedOriginalPrice(),
+                        'saleprice' => $product->getFormattedSalePrice(),
+                        'available' => ($variation->isSellable()),
+                        'imageThumb' => $thumb ? $thumb->src : '',
+                        'image' => $imgObj ? $imgObj->getRelativePath() : '',
+                    ];
                             } ?>
 
             $('#product-options-<?= $bID; ?> select, #product-options-<?= $bID; ?> input').change(function () {
-                var variationdata = <?= json_encode($varationData); ?>;
+                var variationData = <?= json_encode($varationData); ?>;
                 var ar = [];
 
                 $('#product-options-<?= $bID; ?> select.store-product-variation, #product-options-<?= $bID; ?> .store-product-variation:checked').each(function () {
@@ -435,31 +443,31 @@ if (is_object($product) && $product->isActive()) {
                 ar.sort(communityStore.sortNumber);
                 var pdb = $(this).closest('.store-product-block');
 
-                if (variationdata[ar.join('_')]['saleprice']) {
-                    var pricing = '<span class="store-sale-price"><?= t("On Sale: "); ?>' + variationdata[ar.join('_')]['saleprice'] + '</span>&nbsp;' +
+                if (variationData[ar.join('_')]['saleprice']) {
+                    var pricing = '<span class="store-sale-price"><?= t("On Sale: "); ?>' + variationData[ar.join('_')]['saleprice'] + '</span>&nbsp;' +
                         '<?php echo t('was'); ?>' +
-                        '&nbsp;<span class="store-original-price ">' + variationdata[ar.join('_')]['price'] + '</span>';
+                        '&nbsp;<span class="store-original-price ">' + variationData[ar.join('_')]['price'] + '</span>';
 
                     pdb.find('.store-product-price').html(pricing);
                 } else {
-                    pdb.find('.store-product-price').html(variationdata[ar.join('_')]['price']);
+                    pdb.find('.store-product-price').html(variationData[ar.join('_')]['price']);
                 }
 
-                if (variationdata[ar.join('_')]['available']) {
+                if (variationData[ar.join('_')]['available']) {
                     pdb.find('.store-out-of-stock-label').addClass('hidden');
                     pdb.find('.store-btn-add-to-cart').removeClass('hidden');
                 } else {
                     pdb.find('.store-out-of-stock-label').removeClass('hidden');
                     pdb.find('.store-btn-add-to-cart').addClass('hidden');
                 }
-                if (variationdata[ar.join('_')]['imageThumb']) {
+                if (variationData[ar.join('_')]['imageThumb']) {
                     var image = pdb.find('.store-product-primary-image img');
 
                     if (image) {
-                        image.attr('src', variationdata[ar.join('_')]['imageThumb']);
+                        image.attr('src', variationData[ar.join('_')]['imageThumb']);
                         var link = image.parent();
                         if (link) {
-                            link.attr('href', variationdata[ar.join('_')]['image'])
+                            link.attr('href', variationData[ar.join('_')]['image'])
                         }
                     }
                 }

--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -1,8 +1,8 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$defaultImageWidth = 720;
-$defaultImageHeight = 720;
+$defaultImageWidth = Config::get('community_store.defaultSingleProductImageWidth') ?: 720;
+$defaultImageHeight = Config::get('community_store.defaultSingleProductImageHeight') ?: 720;
 
 if (is_object($product) && $product->isActive()) {
     $options = $product->getOptions();

--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -369,6 +369,7 @@ if (is_object($product) && $product->isActive()) {
 
                                 // This is only needed if no thumbnail type was defined or for some reason
                                 // we need to fallback on the legacy thumbnailer.
+                                // We are setting crop to true as it's false by default
                                 $communityStoreImageHelper->setLegacyThumbnailCrop(true);
 
                                 foreach ($images as $secondaryImage) {
@@ -417,7 +418,8 @@ if (is_object($product) && $product->isActive()) {
             <?php
                 $varationData = [];
                             // This is only needed if no thumbnail type was defined or for some reason
-                            // we need to fallback on the legacy thumbnailer. We set it again because we set it to true above
+                            // we need to fallback on the legacy thumbnailer.
+                            // We set it to false again because we set it to true above
                             $communityStoreImageHelper->setLegacyThumbnailCrop(false);
 
                             foreach ($variationLookup as $key => $variation) {

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -1,8 +1,11 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$defaultImageWidth = Config::get('community_store.defaultProductListImageWidth') ?: 400;
-$defaultImageHeight = Config::get('community_store.defaultProductListImageHeight') ?: 280;
+// We want to crop the image so we're providing an object
+// with the crop property set to true since default is false
+$legacyThumbProps = new \stdClass();
+$legacyThumbProps->crop = true;
+$communityStoreImageHelper = Core::make('cs/helper/image', ['product_list', null, $legacyThumbProps]);
 
 $c = Page::getCurrentPage();
 
@@ -99,7 +102,7 @@ if ($products) {
                 <?php
                     $imgObj = $product->getImageObj();
         if (is_object($imgObj)) {
-            $thumb = $ih->getThumbnail($imgObj, $defaultImageWidth, $defaultImageHeight, true); ?>
+            $thumb = $communityStoreImageHelper->getThumbnail($imgObj); ?>
                         <p class="store-product-list-thumbnail">
                             <?php if ($showQuickViewLink) {
                 ?>
@@ -353,7 +356,7 @@ if ($products) {
                 $imgObj = $product->getImageObj();
 
                 if ($imgObj) {
-                    $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultImageWidth, $defaultImageHeight, true);
+                    $thumb = $communityStoreImageHelper->getThumbnail($imgObj);
                 }
 
                 $varationData[$key] = [

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -1,8 +1,8 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$defaultimagewidth = 400;
-$defaultimageheight = 280;
+$defaultImageWidth = 400;
+$defaultImageHeight = 280;
 
 $c = Page::getCurrentPage();
 
@@ -99,7 +99,7 @@ if ($products) {
                 <?php
                     $imgObj = $product->getImageObj();
         if (is_object($imgObj)) {
-            $thumb = $ih->getThumbnail($imgObj, $defaultimagewidth, $defaultimageheight, true); ?>
+            $thumb = $ih->getThumbnail($imgObj, $defaultImageWidth, $defaultImageHeight, true); ?>
                         <p class="store-product-list-thumbnail">
                             <?php if ($showQuickViewLink) {
                 ?>
@@ -353,7 +353,7 @@ if ($products) {
                 $imgObj = $product->getImageObj();
 
                 if ($imgObj) {
-                    $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultimagewidth, $defaultimageheight, true);
+                    $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultImageWidth, $defaultImageHeight, true);
                 }
 
                 $varationData[$key] = [
@@ -366,7 +366,7 @@ if ($products) {
 
 
                             $('#store-form-add-to-cart-list-<?= $product->getID(); ?> select, #store-form-add-to-cart-list-<?= $product->getID(); ?> input').change(function(){
-                                var variationdata = <?= json_encode($varationData); ?>;
+                                var variationData = <?= json_encode($varationData); ?>;
                                 var ar = [];
 
                                 $('#store-form-add-to-cart-list-<?= $product->getID(); ?> select.store-product-variation, #store-form-add-to-cart-list-<?= $product->getID(); ?> .store-product-variation:checked').each(function(){
@@ -377,17 +377,17 @@ if ($products) {
 
                                 var pli = $(this).closest('.store-product-list-item');
 
-                                if (variationdata[ar.join('_')]['saleprice']) {
-                                    var pricing =  '<span class="store-sale-price">'+ variationdata[ar.join('_')]['saleprice']+'</span>' +
-                                        ' <?= t('was'); ?> ' + '<span class="store-original-price">' + variationdata[ar.join('_')]['price'] +'</span>';
+                                if (variationData[ar.join('_')]['saleprice']) {
+                                    var pricing =  '<span class="store-sale-price">'+ variationData[ar.join('_')]['saleprice']+'</span>' +
+                                        ' <?= t('was'); ?> ' + '<span class="store-original-price">' + variationData[ar.join('_')]['price'] +'</span>';
 
                                     pli.find('.store-product-list-price').html(pricing);
 
                                 } else {
-                                    pli.find('.store-product-list-price').html(variationdata[ar.join('_')]['price']);
+                                    pli.find('.store-product-list-price').html(variationData[ar.join('_')]['price']);
                                 }
 
-                                if (variationdata[ar.join('_')]['available']) {
+                                if (variationData[ar.join('_')]['available']) {
                                     pli.find('.store-out-of-stock-label').addClass('hidden');
                                     pli.find('.store-btn-add-to-cart').removeClass('hidden');
                                 } else {
@@ -395,11 +395,11 @@ if ($products) {
                                     pli.find('.store-btn-add-to-cart').addClass('hidden');
                                 }
 
-                                if (variationdata[ar.join('_')]['imageThumb']) {
+                                if (variationData[ar.join('_')]['imageThumb']) {
                                     var image = pli.find('.store-product-list-thumbnail img');
 
                                     if (image) {
-                                        image.attr('src', variationdata[ar.join('_')]['imageThumb']);
+                                        image.attr('src', variationData[ar.join('_')]['imageThumb']);
 
                                     }
                                 }

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -84,7 +84,7 @@ if ($products) {
         if ($productPage->isError() || $productPage->isInTrash()) {
             $productPage = false;
         } ?>
-    
+
         <div class="store-product-list-item <?= $columnClass; ?> <?= $activeclass; ?>">
             <form id="store-form-add-to-cart-list-<?= $product->getID(); ?>" data-product-id="<?= $product->getID(); ?>">
                 <?= $token->output('community_store'); ?>
@@ -117,7 +117,7 @@ if ($products) {
             } ?>
                         </p>
                 <?php
-        }// if is_obj ?>
+        }// if is_obj?>
                 <?php if ($showPrice) {
             ?>
                 <p class="store-product-list-price">
@@ -253,9 +253,11 @@ if ($products) {
                             ?>
                             <div class="store-product-option-group form-group <?= $option->getHandle(); ?>">
                                 <label class="store-product-option-group-label"><?= $option->getName(); ?></label>
-                                <?php if ($displayType != 'radio') { ?>
+                                <?php if ('radio' != $displayType) {
+                                ?>
                                 <select class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : ''; ?> form-control" name="po<?= $option->getID(); ?>">
-                                <?php } ?>
+                                <?php
+                            } ?>
                                     <?php
                                     $firstAvailableVariation = false;
                             $variation = false;
@@ -274,21 +276,27 @@ if ($products) {
                                         $selected = 'selected="selected"';
                                     } ?>
 
-                                    <?php if ($displayType == 'radio') { ?>
+                                    <?php if ('radio' == $displayType) {
+                                        ?>
                                         <div class="radio">
-                                            <label><input type="radio" required class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : '' ?> "
-                                                    <?= $disabled .  ($selected ? 'checked' : ''); ?> name="po<?= $option->getID();?>" value="<?= $optionItem->getID(); ?>" /><?= h($optionItem->getName());?></label>
+                                            <label><input type="radio" required class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : ''; ?> "
+                                                    <?= $disabled . ($selected ? 'checked' : ''); ?> name="po<?= $option->getID(); ?>" value="<?= $optionItem->getID(); ?>" /><?= h($optionItem->getName()); ?></label>
                                         </div>
-                                    <?php } else { ?>
+                                    <?php
+                                    } else {
+                                        ?>
                                         <option <?= $disabled . ' ' . $selected; ?>value="<?= $optionItem->getID(); ?>"><?= $optionItem->getName() . $outOfStock; ?></option>
-                                    <?php } ?>
+                                    <?php
+                                    } ?>
 
                                         <?php
                                 }
                             } ?>
-                                <?php if ($displayType != 'radio') { ?>
+                                <?php if ('radio' != $displayType) {
+                                ?>
                                 </select>
-                                <?php } ?>
+                                <?php
+                            } ?>
                             </div>
                         <?php
                         } elseif ('text' == $optionType) {
@@ -401,7 +409,7 @@ if ($products) {
 
             </form><!-- .product-list-item-inner -->
         </div><!-- .product-list-item -->
-        
+
         <?php
             if (0 == $i % $productsPerRow) {
                 echo "</div>";

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -1,6 +1,9 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
+$defaultimagewidth = 400;
+$defaultimageheight = 280;
+
 $c = Page::getCurrentPage();
 
 if ($products) {
@@ -96,7 +99,7 @@ if ($products) {
                 <?php
                     $imgObj = $product->getImageObj();
         if (is_object($imgObj)) {
-            $thumb = $ih->getThumbnail($imgObj, 400, 280, true); ?>
+            $thumb = $ih->getThumbnail($imgObj, $defaultimagewidth, $defaultimageheight, true); ?>
                         <p class="store-product-list-thumbnail">
                             <?php if ($showQuickViewLink) {
                 ?>
@@ -350,7 +353,7 @@ if ($products) {
                 $imgObj = $product->getImageObj();
 
                 if ($imgObj) {
-                    $thumb = Core::make('helper/image')->getThumbnail($imgObj, 400, 280, true);
+                    $thumb = Core::make('helper/image')->getThumbnail($imgObj, $defaultimagewidth, $defaultimageheight, true);
                 }
 
                 $varationData[$key] = [

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -1,8 +1,8 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$defaultImageWidth = 400;
-$defaultImageHeight = 280;
+$defaultImageWidth = Config::get('community_store.defaultProductListImageWidth') ?: 400;
+$defaultImageHeight = Config::get('community_store.defaultProductListImageHeight') ?: 280;
 
 $c = Page::getCurrentPage();
 

--- a/controller.php
+++ b/controller.php
@@ -17,10 +17,10 @@ class Controller extends Package
     protected $appVersionRequired = '8.0';
     protected $pkgVersion = '2.0.5';
 
-    protected $pkgAutoloaderRegistries = array(
+    protected $pkgAutoloaderRegistries = [
         'src/CommunityStore' => '\Concrete\Package\CommunityStore\Src\CommunityStore',
-        'src/Concrete/Attribute' => 'Concrete\Package\CommunityStore\Attribute'
-    );
+        'src/Concrete/Attribute' => 'Concrete\Package\CommunityStore\Attribute',
+    ];
 
     public function getPackageDescription()
     {
@@ -69,7 +69,8 @@ class Controller extends Package
         $cms->clearCaches();
     }
 
-    public function testForUpgrade() {
+    public function testForUpgrade()
+    {
         $community_store = $this->app->make('Concrete\Core\Package\PackageService')->getByHandle('community_store');
 
         if ($community_store) {
@@ -77,7 +78,7 @@ class Controller extends Package
 
             if (version_compare($installedversion, '2.0', '<')) {
                 $errors = $this->app->make('error');
-                $errors->add(t('Upgrading version 1.x version of Community Store to 2.x is not currently supported. Please immediately revert your community_store package folder to the %s release.',$installedversion ));
+                $errors->add(t('Upgrading version 1.x version of Community Store to 2.x is not currently supported. Please immediately revert your community_store package folder to the %s release.', $installedversion));
 
                 return $errors;
             }
@@ -100,8 +101,20 @@ class Controller extends Package
         Route::register('/store_download/{fID}/{oID}/{hash}', '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Checkout::downloadFile');
     }
 
+    public function registerHelpers()
+    {
+        $singletons = [
+            'cs/helper/image' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image',
+        ];
+
+        foreach ($singletons as $key => $value) {
+            $this->app->singleton($key, $value);
+        }
+    }
+
     public function on_start()
     {
+        $this->registerHelpers();
         $this->registerRoutes();
         $this->registerCategories();
 
@@ -180,14 +193,15 @@ class Controller extends Package
         ";
     }
 
-    private function registerCategories() {
+    private function registerCategories()
+    {
         $this->app['manager/attribute/category']->extend('store_product',
-            function($app) {
+            function ($app) {
                 return $app->make('Concrete\Package\CommunityStore\Attribute\Category\ProductCategory');
             });
 
         $this->app['manager/attribute/category']->extend('store_order',
-            function($app) {
+            function ($app) {
                 return $app->make('Concrete\Package\CommunityStore\Attribute\Category\OrderCategory');
             });
     }

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -122,12 +122,16 @@ class Settings extends DashboardPageController
                 Config::save('community_store.productPublishTarget', $args['productPublishTarget']);
                 Config::save('community_store.defaultSingleProductThumbType', $args['defaultSingleProductThumbType']);
                 Config::save('community_store.defaultProductListThumbType', $args['defaultProductListThumbType']);
+                Config::save('community_store.defaultProductModalThumbType', $args['defaultProductModalThumbType']);
                 Config::save('community_store.defaultSingleProductImageWidth', $args['defaultSingleProductImageWidth'] ?: Image::DEFAULT_SINGLE_PRODUCT_IMG_WIDTH);
                 Config::save('community_store.defaultSingleProductImageHeight', $args['defaultSingleProductImageHeight'] ?: Image::DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT);
                 Config::save('community_store.defaultProductListImageWidth', $args['defaultProductListImageWidth'] ?: Image::DEFAULT_PRODUCT_LIST_IMG_WIDTH);
                 Config::save('community_store.defaultProductListImageHeight', $args['defaultProductListImageHeight'] ?: Image::DEFAULT_PRODUCT_LIST_IMG_HEIGHT);
+                Config::save('community_store.defaultProductModalImageWidth', $args['defaultProductModalImageWidth'] ?: Image::DEFAULT_PRODUCT_MODAL_IMG_WIDTH);
+                Config::save('community_store.defaultProductModalImageHeight', $args['defaultProductModalImageHeight'] ?: Image::DEFAULT_PRODUCT_MODAL_IMG_HEIGHT);
                 Config::save('community_store.defaultSingleProductCrop', $args['defaultSingleProductCrop']);
                 Config::save('community_store.defaultProductListCrop', $args['defaultProductListCrop']);
+                Config::save('community_store.defaultProductListCrop', $args['defaultProductModalCrop']);
                 Config::save('community_store.guestCheckout', $args['guestCheckout']);
                 Config::save('community_store.companyField', $args['companyField']);
                 Config::save('community_store.shoppingDisabled', trim($args['shoppingDisabled']));

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -95,6 +95,10 @@ class Settings extends DashboardPageController
                 Config::save('community_store.emailalerts', $args['emailAlert']);
                 Config::save('community_store.emailalertsname', $args['emailAlertName']);
                 Config::save('community_store.productPublishTarget', $args['productPublishTarget']);
+                Config::save('community_store.defaultSingleProductImageWidth', $args['defaultSingleProductImageWidth'] ?: 720);
+                Config::save('community_store.defaultSingleProductImageHeight', $args['defaultSingleProductImageHeight'] ?: 720);
+                Config::save('community_store.defaultProductListImageWidth', $args['defaultProductListImageWidth'] ?: 400);
+                Config::save('community_store.defaultProductListImageHeight', $args['defaultProductListImageHeight'] ?: 280);
                 Config::save('community_store.guestCheckout', $args['guestCheckout']);
                 Config::save('community_store.companyField', $args['companyField']);
                 Config::save('community_store.shoppingDisabled', trim($args['shoppingDisabled']));
@@ -142,6 +146,7 @@ class Settings extends DashboardPageController
 
                 $this->saveOrderStatuses($args);
                 $this->flash('success', t('Settings Saved'));
+
                 return \Redirect::to('/dashboard/store/settings');
             }
         }
@@ -173,6 +178,7 @@ class Settings extends DashboardPageController
     public function validate($args)
     {
         $e = Core::make('helper/validation/error');
+        $nv = Core::make('helper/validation/numbers');
 
         if ("" == $args['symbol']) {
             $e->add(t('You must set a currency symbol'));
@@ -205,6 +211,20 @@ class Settings extends DashboardPageController
                 if (count($taxClassRates) > 1) {
                     $e->add(t("The %s Tax Class can't contain more than 1 Tax Rate if you change how the taxes are calculated", $taxClass->getTaxClassName()));
                 }
+            }
+        }
+
+        $sizeFields = [
+            'defaultSingleProductImageWidth',
+            'defaultSingleProductImageHeight',
+            'defaultProductListImageWidth',
+            'defaultProductListImageHeight',
+        ];
+
+        foreach ($sizeFields as $field) {
+            if (isset($args[$field]) && !empty($args[$field]) && !$nv->integer($args[$field])) {
+                $e->add(t("All legacy thumbnail dimensions must be positive integers"));
+                break;
             }
         }
 

--- a/elements/product_modal.php
+++ b/elements/product_modal.php
@@ -1,115 +1,129 @@
 <?php defined('C5_EXECUTE') or die("Access Denied.");
-use \Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation as StoreProductVariation;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation as StoreProductVariation;
+
+$communityStoreImageHelper = Core::make('cs/helper/image', ['product_modal']);
 ?>
-<form class="store-product-modal" id="store-form-add-to-cart-modal-<?= $product->getID()?>">
+<form class="store-product-modal" id="store-form-add-to-cart-modal-<?= $product->getID(); ?>">
 
     <div class="store-product-modal-info-shell">
 
         <a href="#" class="store-modal-exit">x</a>
-        <h4 class="store-product-modal-title"><?= $product->getName()?></h4>
+        <h4 class="store-product-modal-title"><?= $product->getName(); ?></h4>
 
         <p class="store-product-modal-thumb">
             <?php
             $imgObj = $product->getImageObj();
-            $ih = Core::make("helper/image");
-            $thumb = $ih->getThumbnail($imgObj,560,999,false);
+            $thumb = $communityStoreImageHelper->getThumbnail($imgObj);
             ?>
-            <img src="<?= $thumb->src?>">
+            <img src="<?= $thumb->src; ?>">
         </p>
 
 
-        <p class="store-product-modal-price"><?= $product->getFormattedPrice()?></p>
+        <p class="store-product-modal-price"><?= $product->getFormattedPrice(); ?></p>
         <div class="store-product-modal-details">
-            <?= $product->getDesc()?>
+            <?= $product->getDesc(); ?>
         </div>
         <div class="store-product-modal-options">
-            <?php if (Config::get('community_store.shoppingDisabled') != 'all') { ?>
+            <?php if ('all' != Config::get('community_store.shoppingDisabled')) {
+                ?>
             <div class="store-product-modal-quantity form-group">
-                <?php if ($product->allowQuantity()) { ?>
-                    <label class="store-product-option-group-label"><?= t('Quantity') ?></label>
-                    <input type="number" name="quantity" class="store-product-qty form-control" value="1" min="1" step="1" max="<?= $product->getQty()?>">
-                <?php } else { ?>
+                <?php if ($product->allowQuantity()) {
+                    ?>
+                    <label class="store-product-option-group-label"><?= t('Quantity'); ?></label>
+                    <input type="number" name="quantity" class="store-product-qty form-control" value="1" min="1" step="1" max="<?= $product->getQty(); ?>">
+                <?php
+                } else {
+                    ?>
                     <input type="hidden" name="quantity" class="store-product-qty form-control" value="1">
-                <?php } ?>
+                <?php
+                } ?>
             </div>
-            <?php } ?>
+            <?php
+            } ?>
             <?php
             foreach ($product->getOptions() as $option) {
-            $optionItems = $option->getOptionItems();
+                $optionItems = $option->getOptionItems();
 
-             if (!empty($optionItems)) { ?>
+                if (!empty($optionItems)) {
+                    ?>
                 <div class="store-product-option-group form-group">
-                    <label class="store-product-option-group-label"><?= $option->getName() ?></label>
-                    <select class="store-product-option form-control" name="po<?= $option->getID() ?>">
+                    <label class="store-product-option-group-label"><?= $option->getName(); ?></label>
+                    <select class="store-product-option form-control" name="po<?= $option->getID(); ?>">
                         <?php
                         foreach ($optionItems as $optionItem) {
-                            if (!$optionItem->isHidden()) { ?>
-                                <option value="<?= $optionItem->getID() ?>"><?= $optionItem->getName() ?></option>
-                            <?php }
+                            if (!$optionItem->isHidden()) {
+                                ?>
+                                <option value="<?= $optionItem->getID(); ?>"><?= $optionItem->getName(); ?></option>
+                            <?php
+                            }
                             // below is an example of a radio button, comment out the <select> and <option> tags to use instead
-                            //echo '<input type="radio" name="po'.$option->getID().'" value="'. $optionItem->getID(). '" />' . $optionItem->getName() . '<br />'; ?>
-                        <?php } ?>
+                            //echo '<input type="radio" name="po'.$option->getID().'" value="'. $optionItem->getID(). '" />' . $optionItem->getName() . '<br />';?>
+                        <?php
+                        } ?>
                     </select>
                 </div>
-            <?php }
+            <?php
+                }
             } ?>
         </div>
-        <input type="hidden" name="pID" value="<?= $product->getID()?>">
-        <?php if (Config::get('community_store.shoppingDisabled') != 'all') { ?>
+        <input type="hidden" name="pID" value="<?= $product->getID(); ?>">
+        <?php if ('all' != Config::get('community_store.shoppingDisabled')) {
+                ?>
         <div class="store-product-modal-buttons">
-            <p><button data-add-type="modal" data-product-id="<?= $product->getID()?>" class="store-btn-add-to-cart btn btn-primary <?= ($product->isSellable() ? '' : 'hidden');?> "><?=  ($btnText ? h($btnText) : t("Add to Cart"))?></button></p>
-            <p class="store-out-of-stock-label alert alert-warning <?= ($product->isSellable() ? 'hidden' : '');?>"><?= t("Out of Stock")?></p>
+            <p><button data-add-type="modal" data-product-id="<?= $product->getID(); ?>" class="store-btn-add-to-cart btn btn-primary <?= ($product->isSellable() ? '' : 'hidden'); ?> "><?=  ($btnText ? h($btnText) : t("Add to Cart")); ?></button></p>
+            <p class="store-out-of-stock-label alert alert-warning <?= ($product->isSellable() ? 'hidden' : ''); ?>"><?= t("Out of Stock"); ?></p>
         </div>
-        <?php } ?>
+        <?php
+            } ?>
     </div>
 </form>
 
 <?php
 if ($product->hasVariations()) {
-    $variations = StoreProductVariation::getVariationsForProduct($product);
+                $variations = StoreProductVariation::getVariationsForProduct($product);
 
-    $variationLookup = array();
+                $variationLookup = [];
 
-    if (!empty($variations)) {
-        foreach ($variations as $variation) {
-            // returned pre-sorted
-            $ids = $variation->getOptionItemIDs();
-            $variationLookup[implode('_', $ids)] = $variation;
-        }
-    }
-}
+                if (!empty($variations)) {
+                    foreach ($variations as $variation) {
+                        // returned pre-sorted
+                        $ids = $variation->getOptionItemIDs();
+                        $variationLookup[implode('_', $ids)] = $variation;
+                    }
+                }
+            }
 ?>
 
-<?php if ($product->hasVariations() && !empty($variationLookup)) {?>
+<?php if ($product->hasVariations() && !empty($variationLookup)) {
+    ?>
     <script>
         $(function() {
             <?php
-            $varationData = array();
-            foreach($variationLookup as $key=>$variation) {
-                $product->setVariation($variation);
+            $varationData = [];
+    foreach ($variationLookup as $key => $variation) {
+        $product->setVariation($variation);
 
-                $imgObj = $product->getImageObj();
+        $imgObj = $product->getImageObj();
 
-                if ($imgObj) {
-                    $thumb = Core::make('helper/image')->getThumbnail($imgObj,560,999,false);
-                }
+        if ($imgObj) {
+            $thumb = $communityStoreImageHelper->getThumbnail($imgObj);
+        }
 
-                $varationData[$key] = array(
-                'price'=>$product->getFormattedOriginalPrice(),
-                'saleprice'=>$product->getFormattedSalePrice(),
-                'available'=>($variation->isSellable()),
-                'imageThumb'=>$thumb ? $thumb->src : '',
-                'image'=>$imgObj ? $imgObj->getRelativePath() : '');
+        $varationData[$key] = [
+                'price' => $product->getFormattedOriginalPrice(),
+                'saleprice' => $product->getFormattedSalePrice(),
+                'available' => ($variation->isSellable()),
+                'imageThumb' => $thumb ? $thumb->src : '',
+                'image' => $imgObj ? $imgObj->getRelativePath() : '', ];
+    } ?>
 
-            } ?>
 
-
-            $('#store-form-add-to-cart-modal-<?= $product->getID()?> select').change(function(){
+            $('#store-form-add-to-cart-modal-<?= $product->getID(); ?> select').change(function(){
 
                 var variationdata = <?= json_encode($varationData); ?>;
                 var ar = [];
 
-                $('#store-form-add-to-cart-modal-<?= $product->getID()?> select').each(function(){
+                $('#store-form-add-to-cart-modal-<?= $product->getID(); ?> select').each(function(){
                     ar.push($(this).val());
                 });
 
@@ -119,7 +133,7 @@ if ($product->hasVariations()) {
 
                 if (variationdata[ar.join('_')]['saleprice']) {
                     var pricing =  '<span class="store-sale-price">'+ variationdata[ar.join('_')]['saleprice']+'</span>' +
-                        ' <?= t('was');?> ' + '<span class="store-original-price">' + variationdata[ar.join('_')]['price'] +'</span>';
+                        ' <?= t('was'); ?> ' + '<span class="store-original-price">' + variationdata[ar.join('_')]['price'] +'</span>';
 
                     pli.find('.store-product-modal-price').html(pricing);
 
@@ -147,4 +161,5 @@ if ($product->hasVariations()) {
             });
         });
     </script>
-<?php } ?>
+<?php
+} ?>

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -1,7 +1,7 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
 	    <div class="ccm-dashboard-header-buttons">
-            <a href="<?= \URL::to('/dashboard/store/settings/shipping'); ?>" class="btn btn-primary"><i class="fa fa-truck"></i> <?= t("Shipping Methods"); ?></a>
+            <a href="<?= \URL::to('/dashboard/store/settings/shipping'); ?>" class="btn btn-primary"><i class="fa fa-truck fa-flip-horizontal"></i> <?= t("Shipping Methods"); ?></a>
             <a href="<?= \URL::to('/dashboard/store/settings/tax'); ?>" class="btn btn-primary"><i class="fa fa-money"></i> <?= t("Tax Rates"); ?></a>
         </div>
 

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -304,7 +304,11 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                             <?php echo $form->select('defaultProductModalThumbType', $thumbnailTypes, Config::get('community_store.defaultProductModalThumbType')); ?>
                         </div>
                     </div>
-
+                    <div class="row">
+                        <div class="alert alert-info">
+                            <?php echo t("%sThumbnail types will be used if selected because they offer better performance. %sIf they are not available for any reason, the Legacy Thumbnailer Generator set below will be used as fallback to avoid any disruption. %sReasons thumbnail types can be unavailable are if you don't select one, if it was deleted or if the image displayed doesn't have a thumbnail of the selected type.%s", '<p>', '</p><p>', '</p><p>', '</p>'); ?>
+                        </div>
+                    </div>
                     <div class="row">
                         <h4 class="col-md-12"><?php echo t("Single Product - Legacy Thumbnail Generator"); ?></h4>
                         <div class="form-group col-md-4">

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -1,4 +1,7 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
+
+?>
 
 	    <div class="ccm-dashboard-header-buttons">
             <a href="<?= \URL::to('/dashboard/store/settings/shipping'); ?>" class="btn btn-primary"><i class="fa fa-truck fa-flip-horizontal"></i> <?= t("Shipping Methods"); ?></a>
@@ -279,45 +282,77 @@
                     </div>
 
                     <h3><?= t("Product Images"); ?></h3>
-                    <h4><?= t("Single Product - Legacy Thumbnail Generator"); ?></h4>
+
                     <div class="row">
+                        <h4 class="col-md-12"><?= t("Product Thumbnail Types"); ?></h4>
                         <div class="form-group col-md-6">
-                            <?= $form->label('defaultSingleProductImageWidth', t('Single Product Image Width'), ['class' => 'sr-only']); ?>
-                            <div class="input-group">
-                                <div class="input-group-addon"><?php echo t("Width"); ?></div>
-                                <?= $form->number('defaultSingleProductImageWidth', Config::get('community_store.defaultSingleProductImageWidth') ?: 720, ['min' => '0', 'step' => '1']); ?>
-                                <div class="input-group-addon">px</div>
-                            </div>
+                            <?= $form->label('defaultSingleProductThumbType', t('Single Product Thumbnail Type')); ?>
+                            <?= $form->select('defaultSingleProductThumbType', $thumbnailTypes, Config::get('community_store.defaultSingleProductThumbType')); ?>
                         </div>
 
                         <div class="form-group col-md-6">
-                            <?= $form->label('defaultSingleProductImageHeight', t('Single Product Image Height'), ['class' => 'sr-only']); ?>
-                            <div class="input-group">
-                                <div class="input-group-addon"><?php echo t("Height"); ?></div>
-                                <?= $form->number('defaultSingleProductImageHeight', Config::get('community_store.defaultSingleProductImageHeight') ?: 720, ['min' => '0', 'step' => '1']); ?>
-                                <div class="input-group-addon">px</div>
-                            </div>
+                            <?= $form->label('defaultProductListThumbType', t('Product List Thumbnail Type')); ?>
+                            <?= $form->select('defaultProductListThumbType', $thumbnailTypes, Config::get('community_store.defaultProductListThumbType')); ?>
                         </div>
                     </div>
 
-                    <h4><?= t("Product List - Legacy Thumbnail Generator"); ?></h4>
                     <div class="row">
-                        <div class="form-group col-md-6">
-                            <?= $form->label('defaultProductListImageWidth', t('Product List Image Width'), ['class' => 'sr-only']); ?>
+                        <h4 class="col-md-12"><?= t("Single Product - Legacy Thumbnail Generator"); ?></h4>
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultSingleProductImageWidth', t('Image Width')); ?>
                             <div class="input-group">
-                                <div class="input-group-addon"><?php echo t("Width"); ?></div>
-                                <?= $form->number('defaultProductListImageWidth', Config::get('community_store.defaultProductListImageWidth') ?: 400, ['min' => '0', 'step' => '1']); ?>
+                                <?= $form->number('defaultSingleProductImageWidth', Config::get('community_store.defaultSingleProductImageWidth') ?: Image::DEFAULT_SINGLE_PRODUCT_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
                                 <div class="input-group-addon">px</div>
+                            </div>
+                            <div class="help-block">
+                                <?= t("Default value: %s", Image::DEFAULT_SINGLE_PRODUCT_IMG_WIDTH); ?>
                             </div>
                         </div>
 
-                        <div class="form-group col-md-6">
-                            <?= $form->label('defaultProductListImageHeight', t('Product List Image Height'), ['class' => 'sr-only']); ?>
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultSingleProductImageHeight', t('Image Height')); ?>
                             <div class="input-group">
-                                <div class="input-group-addon"><?php echo t("Height"); ?></div>
-                                <?= $form->number('defaultProductListImageHeight', Config::get('community_store.defaultProductListImageHeight') ?: 280, ['min' => '0', 'step' => '1']); ?>
+                                <?= $form->number('defaultSingleProductImageHeight', Config::get('community_store.defaultSingleProductImageHeight') ?: Image::DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
                                 <div class="input-group-addon">px</div>
                             </div>
+                            <div class="help-block">
+                                <?= t("Default value: %s", Image::DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT); ?>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultSingleProductCrop', t('Image cropping')); ?>
+                            <?= $form->select('defaultSingleProductCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultSingleProductCrop')); ?>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <h4 class="col-md-12"><?= t("Product List - Legacy Thumbnail Generator"); ?></h4>
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultProductListImageWidth', t('Image Width')); ?>
+                            <div class="input-group">
+                                <?= $form->number('defaultProductListImageWidth', Config::get('community_store.defaultProductListImageWidth') ?: Image::DEFAULT_PRODUCT_LIST_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                            <div class="help-block">
+                                <?= t("Default value: %s", Image::DEFAULT_PRODUCT_LIST_IMG_WIDTH); ?>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultProductListImageHeight', t('Image Height')); ?>
+                            <div class="input-group">
+                                <?= $form->number('defaultProductListImageHeight', Config::get('community_store.defaultProductListImageHeight') ?: Image::DEFAULT_PRODUCT_LIST_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                            <div class="help-block">
+                                <?= t("Default value: %s", Image::DEFAULT_PRODUCT_LIST_IMG_HEIGHT); ?>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultProductListCrop', t('Image cropping')); ?>
+                            <?= $form->select('defaultProductListCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultProductListCrop')); ?>
                         </div>
                     </div>
                 </div>

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -4,105 +4,106 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 ?>
 
 	    <div class="ccm-dashboard-header-buttons">
-            <a href="<?= \URL::to('/dashboard/store/settings/shipping'); ?>" class="btn btn-primary"><i class="fa fa-truck fa-flip-horizontal"></i> <?= t("Shipping Methods"); ?></a>
-            <a href="<?= \URL::to('/dashboard/store/settings/tax'); ?>" class="btn btn-primary"><i class="fa fa-money"></i> <?= t("Tax Rates"); ?></a>
+            <a href="<?php echo \URL::to('/dashboard/store/settings/shipping'); ?>" class="btn btn-primary"><i class="fa fa-truck fa-flip-horizontal"></i> <?php echo t("Shipping Methods"); ?></a>
+            <a href="<?php echo \URL::to('/dashboard/store/settings/tax'); ?>" class="btn btn-primary"><i class="fa fa-money"></i> <?php echo t("Tax Rates"); ?></a>
         </div>
 
-	    <form method="post" action="<?= $view->action('save'); ?>">
-            <?= $token->output('community_store'); ?>
+	    <form method="post" action="<?php echo $view->action('save'); ?>">
+            <?php echo $token->output('community_store'); ?>
 
             <div class="row">
                 <div class="col-sm-3">
 
                     <ul class="nav nav-pills nav-stacked">
-                            <li class="active"><a href="#settings-currency" data-pane-toggle ><?= t('Currency'); ?></a></li>
-                            <li><a href="#settings-tax" data-pane-toggle><?= t('Tax'); ?></a></li>
-                            <li><a href="#settings-shipping" data-pane-toggle><?= t('Shipping'); ?></a></li>
-                            <li><a href="#settings-payments" data-pane-toggle><?= t('Payments'); ?></a></li>
-                            <li><a href="#settings-order-statuses" data-pane-toggle><?= t('Fulfilment Statuses'); ?></a></li>
-                            <li><a href="#settings-notifications" data-pane-toggle><?= t('Notifications and Receipts'); ?></a></li>
-                            <li><a href="#settings-products" data-pane-toggle><?= t('Products'); ?></a></li>
-                            <li><a href="#settings-checkout" data-pane-toggle><?= t('Cart and Checkout'); ?></a></li>
-                            <li><a href="#settings-orders" data-pane-toggle><?= t('Orders'); ?></a></li>
+                            <li class="active"><a href="#settings-currency" data-pane-toggle ><?php echo t('Currency'); ?></a></li>
+                            <li><a href="#settings-tax" data-pane-toggle><?php echo t('Tax'); ?></a></li>
+                            <li><a href="#settings-shipping" data-pane-toggle><?php echo t('Shipping'); ?></a></li>
+                            <li><a href="#settings-payments" data-pane-toggle><?php echo t('Payments'); ?></a></li>
+                            <li><a href="#settings-order-statuses" data-pane-toggle><?php echo t('Fulfilment Statuses'); ?></a></li>
+                            <li><a href="#settings-notifications" data-pane-toggle><?php echo t('Notifications and Receipts'); ?></a></li>
+                            <li><a href="#settings-products" data-pane-toggle><?php echo t('Products'); ?></a></li>
+                            <li><a href="#settings-product-images" data-pane-toggle><?php echo t('Product Images'); ?></a></li>
+                            <li><a href="#settings-checkout" data-pane-toggle><?php echo t('Cart and Checkout'); ?></a></li>
+                            <li><a href="#settings-orders" data-pane-toggle><?php echo t('Orders'); ?></a></li>
                         </ul>
 
                 </div>
 
                 <div class="col-sm-9 store-pane active" id="settings-currency">
-                    <h3><?= t('Currency Settings'); ?></h3>
+                    <h3><?php echo t('Currency Settings'); ?></h3>
                     <div class="row">
                         <div class="form-group col-md-6">
-                            <?= $form->label('symbol', t('Currency Symbol')); ?>
-                            <?= $form->text('symbol', Config::get('community_store.symbol')); ?>
+                            <?php echo $form->label('symbol', t('Currency Symbol')); ?>
+                            <?php echo $form->text('symbol', Config::get('community_store.symbol')); ?>
                         </div>
 
                         <div class="form-group col-md-6">
-                            <?= $form->label('currency', t('Currency Code')); ?>
-                            <?= $form->text('currency', Config::get('community_store.currency')); ?>
+                            <?php echo $form->label('currency', t('Currency Code')); ?>
+                            <?php echo $form->text('currency', Config::get('community_store.currency')); ?>
                         </div>
                     </div>
                     <div class="row">
                         <div class="form-group col-md-6">
-                            <?= $form->label('thousand', t('Thousands Separator')); ?>
-                            <?= $form->text('thousand', Config::get('community_store.thousand')); ?>
-                            <span class="help-block"><?= t('e.g. , or a space'); ?></span>
+                            <?php echo $form->label('thousand', t('Thousands Separator')); ?>
+                            <?php echo $form->text('thousand', Config::get('community_store.thousand')); ?>
+                            <span class="help-block"><?php echo t('e.g. , or a space'); ?></span>
                         </div>
                         <div class="form-group col-md-6">
-                            <?= $form->label('whole', t('Whole Number Separator')); ?>
-                            <?= $form->text('whole', Config::get('community_store.whole')); ?>
-                            <span class="help-block"><?= t('e.g. period or a comma'); ?></span>
+                            <?php echo $form->label('whole', t('Whole Number Separator')); ?>
+                            <?php echo $form->text('whole', Config::get('community_store.whole')); ?>
+                            <span class="help-block"><?php echo t('e.g. period or a comma'); ?></span>
                         </div>
                     </div>
 
                 </div><!-- #settings-currency -->
 
                 <div class="col-sm-9 store-pane" id="settings-tax">
-                    <h3><?= t('Tax Settings'); ?></h3>
+                    <h3><?php echo t('Tax Settings'); ?></h3>
 
                     <div class="form-group">
-                        <label for="calculation"><?= t("Are Prices Entered with Tax Included?"); ?></label>
-                        <?= $form->select('calculation', ['add' => t("No, I will enter product prices EXCLUSIVE of tax"), 'extract' => t("Yes, I will enter product prices INCLUSIVE of tax")], Config::get('community_store.calculation')); ?>
+                        <label for="calculation"><?php echo t("Are Prices Entered with Tax Included?"); ?></label>
+                        <?php echo $form->select('calculation', ['add' => t("No, I will enter product prices EXCLUSIVE of tax"), 'extract' => t("Yes, I will enter product prices INCLUSIVE of tax")], Config::get('community_store.calculation')); ?>
                     </div>
 
                     <div class="form-group">
-                        <label for="vat_number"><?= t("Enable EU VAT Number Options?"); ?></label>
-                        <?= $form->select('vat_number', ['0' => t("No, I don't need this"), '1' => t("Yes, enable VAT Number options")], Config::get('community_store.vat_number')); ?>
+                        <label for="vat_number"><?php echo t("Enable EU VAT Number Options?"); ?></label>
+                        <?php echo $form->select('vat_number', ['0' => t("No, I don't need this"), '1' => t("Yes, enable VAT Number options")], Config::get('community_store.vat_number')); ?>
                     </div>
 
                 </div>
 
                 <div class="col-sm-9 store-pane" id="settings-shipping">
 
-                    <h3><?= t("Shipping Units"); ?></h3>
+                    <h3><?php echo t("Shipping Units"); ?></h3>
                     <div class="row">
                         <div class="col-xs-6">
                             <div class="form-group">
-                                <?= $form->label('weightUnit', t('Units for Weight')); ?>
+                                <?php echo $form->label('weightUnit', t('Units for Weight')); ?>
                                 <?php // do not add other units to this list. these are specific to making calculated shipping work?>
-                                <?= $form->select('weightUnit', ['oz' => t('oz'), 'lb' => t('lb'), 'kg' => t('kg'), 'g' => t('g')], Config::get('community_store.weightUnit')); ?>
+                                <?php echo $form->select('weightUnit', ['oz' => t('oz'), 'lb' => t('lb'), 'kg' => t('kg'), 'g' => t('g')], Config::get('community_store.weightUnit')); ?>
                             </div>
                         </div>
                         <div class="col-xs-6">
                             <div class="form-group">
-                                <?= $form->label('sizeUnit', t('Units for Size')); ?>
+                                <?php echo $form->label('sizeUnit', t('Units for Size')); ?>
                                 <?php // do not add other units to this list. these are specific to making calculated shipping work?>
-                                <?= $form->select('sizeUnit', ['in' => t('in'), 'cm' => t('cm'), 'mm' => t('mm')], Config::get('community_store.sizeUnit')); ?>
+                                <?php echo $form->select('sizeUnit', ['in' => t('in'), 'cm' => t('cm'), 'mm' => t('mm')], Config::get('community_store.sizeUnit')); ?>
                             </div>
                         </div>
                     </div>
 
                     <div class="row">
                         <div class="col-xs-12">
-                            <label><?= $form->checkbox('deliveryInstructions', '1', Config::get('community_store.deliveryInstructions') ? '1' : '0'); ?>
-                                <?= t('Include Delivery Instructions field in checkout'); ?></label>
+                            <label><?php echo $form->checkbox('deliveryInstructions', '1', Config::get('community_store.deliveryInstructions') ? '1' : '0'); ?>
+                                <?php echo t('Include Delivery Instructions field in checkout'); ?></label>
                         </div>
                     </div>
 
-                    <h3><?= t("Multiple Packages Support"); ?></h3>
+                    <h3><?php echo t("Multiple Packages Support"); ?></h3>
                     <div class="row">
                         <div class="col-xs-12">
-                            <label><?= $form->checkbox('multiplePackages', '1', Config::get('community_store.multiplePackages') ? '1' : '0'); ?>
-                                <?= t('Enable Package(s) Data fields'); ?></label>
+                            <label><?php echo $form->checkbox('multiplePackages', '1', Config::get('community_store.multiplePackages') ? '1' : '0'); ?>
+                                <?php echo t('Enable Package(s) Data fields'); ?></label>
                             <span class="help-block">Allows multiple packages to be defined per product configuration, to be used by advanced shipping methods</span>
                         </div>
                     </div>
@@ -112,7 +113,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                 </div><!-- #settings-shipping -->
 
                 <div class="col-sm-9 store-pane" id="settings-payments">
-                    <h3><?= t("Payment Methods"); ?></h3>
+                    <h3><?php echo t("Payment Methods"); ?></h3>
                     <?php
                         if ($installedPaymentMethods) {
                             foreach ($installedPaymentMethods as $pm) {
@@ -120,28 +121,28 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
                             <div class="panel panel-default">
 
-                                <div class="panel-heading"><?= t($pm->getName()); ?></div>
+                                <div class="panel-heading"><?php echo t($pm->getName()); ?></div>
                                 <div class="panel-body">
                                     <div class="form-group paymentMethodEnabled">
-                                        <input type="hidden" name="paymentMethodHandle[<?= $pm->getID(); ?>]" value="<?= $pm->getHandle(); ?>">
-                                        <label><?= t("Enabled"); ?></label>
+                                        <input type="hidden" name="paymentMethodHandle[<?php echo $pm->getID(); ?>]" value="<?php echo $pm->getHandle(); ?>">
+                                        <label><?php echo t("Enabled"); ?></label>
                                         <?php
                                             echo $form->select("paymentMethodEnabled[" . $pm->getID() . "]", [0 => t("No"), 1 => t("Yes")], $pm->isEnabled()); ?>
                                     </div>
-                                    <div id="paymentMethodForm-<?= $pm->getID(); ?>" style="display:<?= $pm->isEnabled() ? 'block' : 'none'; ?>">
+                                    <div id="paymentMethodForm-<?php echo $pm->getID(); ?>" style="display:<?php echo $pm->isEnabled() ? 'block' : 'none'; ?>">
                                         <div class="row">
                                             <div class="form-group col-sm-6">
-                                                <label><?= t("Display Name (on checkout)"); ?></label>
-                                                <?= $form->text('paymentMethodDisplayName[' . $pm->getID() . ']', $pm->getDisplayName()); ?>
+                                                <label><?php echo t("Display Name (on checkout)"); ?></label>
+                                                <?php echo $form->text('paymentMethodDisplayName[' . $pm->getID() . ']', $pm->getDisplayName()); ?>
                                             </div>
                                             <div class="form-group col-sm-6">
-                                                <label><?= t("Button Label"); ?></label>
-                                                <?= $form->text('paymentMethodButtonLabel[' . $pm->getID() . ']', $pm->getButtonLabel(), ['placeholder' => t('Optional')]); ?>
+                                                <label><?php echo t("Button Label"); ?></label>
+                                                <?php echo $form->text('paymentMethodButtonLabel[' . $pm->getID() . ']', $pm->getButtonLabel(), ['placeholder' => t('Optional')]); ?>
                                             </div>
                                         </div>
                                         <div class="form-group">
-                                            <label><?= t("Sort Order"); ?></label>
-                                            <?= $form->text('paymentMethodSortOrder[' . $pm->getID() . ']', $pm->getSortOrder()); ?>
+                                            <label><?php echo t("Sort Order"); ?></label>
+                                            <?php echo $form->text('paymentMethodSortOrder[' . $pm->getID() . ']', $pm->getSortOrder()); ?>
                                         </div>
                                         <?php
                                             $pm->renderDashboardForm(); ?>
@@ -173,7 +174,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                 </div><!-- #settings-payments -->
 
                 <div class="col-sm-9 store-pane" id="settings-order-statuses">
-                    <h3><?= t("Fulfilment Statuses"); ?></h3>
+                    <h3><?php echo t("Fulfilment Statuses"); ?></h3>
                     <?php
                     if (count($orderStatuses) > 0) {
                         ?>
@@ -183,24 +184,24 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                                 <thead>
                                 <tr>
                                     <th rowspan="1">&nbsp;</th>
-                                    <th rowspan="1"><?= t('Display Name'); ?></th>
-                                    <th rowspan="1"><?= t('Default Status'); ?></th>
-                                    <th colspan="2" style="display:none;"><?= t('Send Change Notifications to...'); ?></th>
+                                    <th rowspan="1"><?php echo t('Display Name'); ?></th>
+                                    <th rowspan="1"><?php echo t('Default Status'); ?></th>
+                                    <th colspan="2" style="display:none;"><?php echo t('Send Change Notifications to...'); ?></th>
                                 </tr>
                                 <tr style="display:none;">
-                                    <th><?= t('Site'); ?></th>
-                                    <th><?= t('Customer'); ?></th>
+                                    <th><?php echo t('Site'); ?></th>
+                                    <th><?php echo t('Customer'); ?></th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 <?php foreach ($orderStatuses as $orderStatus) {
                             ?>
                                     <tr>
-                                        <td class="sorthandle"><input type="hidden" name="osID[]" value="<?= $orderStatus->getID(); ?>"><i class="fa fa-arrows-v"></i></td>
-                                        <td><input type="text" name="osName[]" value="<?= t($orderStatus->getName()); ?>" placeholder="<?= $orderStatus->getReadableHandle(); ?>" class="form-control ccm-input-text"></td>
-                                        <td><input type="radio" name="osIsStartingStatus" value="<?= $orderStatus->getID(); ?>" <?= $orderStatus->isStartingStatus() ? 'checked' : ''; ?>></td>
-                                        <td style="display:none;"><input type="checkbox" name="osInformSite[]" value="1" <?= $orderStatus->getInformSite() ? 'checked' : ''; ?> class="form-control"></td>
-                                        <td style="display:none;"><input type="checkbox" name="osInformCustomer[]" value="1" <?= $orderStatus->getInformCustomer() ? 'checked' : ''; ?> class="form-control"></td>
+                                        <td class="sorthandle"><input type="hidden" name="osID[]" value="<?php echo $orderStatus->getID(); ?>"><i class="fa fa-arrows-v"></i></td>
+                                        <td><input type="text" name="osName[]" value="<?php echo t($orderStatus->getName()); ?>" placeholder="<?php echo $orderStatus->getReadableHandle(); ?>" class="form-control ccm-input-text"></td>
+                                        <td><input type="radio" name="osIsStartingStatus" value="<?php echo $orderStatus->getID(); ?>" <?php echo $orderStatus->isStartingStatus() ? 'checked' : ''; ?>></td>
+                                        <td style="display:none;"><input type="checkbox" name="osInformSite[]" value="1" <?php echo $orderStatus->getInformSite() ? 'checked' : ''; ?> class="form-control"></td>
+                                        <td style="display:none;"><input type="checkbox" name="osInformCustomer[]" value="1" <?php echo $orderStatus->getInformCustomer() ? 'checked' : ''; ?> class="form-control"></td>
                                     </tr>
                                 <?php
                         } ?>
@@ -230,42 +231,42 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                 </div><!-- #settings-order-statuses -->
 
                 <div class="col-sm-9 store-pane" id="settings-notifications">
-                    <h3><?= t('Notification Emails'); ?></h3>
+                    <h3><?php echo t('Notification Emails'); ?></h3>
 
                     <div class="form-group">
-                        <?= $form->label('notificationEmails', t('Send order notification to email')); ?>
-                        <?= $form->text('notificationEmails', Config::get('community_store.notificationemails'), ['placeholder' => t('Email Address')]); ?>
-                        <span class="help-block"><?= t('separate multiple emails with commas'); ?></span>
+                        <?php echo $form->label('notificationEmails', t('Send order notification to email')); ?>
+                        <?php echo $form->text('notificationEmails', Config::get('community_store.notificationemails'), ['placeholder' => t('Email Address')]); ?>
+                        <span class="help-block"><?php echo t('separate multiple emails with commas'); ?></span>
                     </div>
 
-                    <h4><?= t('Emails Sent From'); ?></h4>
+                    <h4><?php echo t('Emails Sent From'); ?></h4>
 
                     <div class="row">
                         <div class="col-xs-6">
                             <div class="form-group">
-                                <?= $form->label('emailAlert', t('From Email')); ?>
-                                <?= $form->text('emailAlert', Config::get('community_store.emailalerts'), ['placeholder' => t('From Email Address')]); ?>
+                                <?php echo $form->label('emailAlert', t('From Email')); ?>
+                                <?php echo $form->text('emailAlert', Config::get('community_store.emailalerts'), ['placeholder' => t('From Email Address')]); ?>
                             </div>
                         </div>
 
                         <div class="col-xs-6">
                             <div class="form-group">
-                                <?= $form->label('emailAlertName', t('From Name')); ?>
-                                <?= $form->text('emailAlertName', Config::get('community_store.emailalertsname'), ['placeholder' => t('From Name')]); ?>
+                                <?php echo $form->label('emailAlertName', t('From Name')); ?>
+                                <?php echo $form->text('emailAlertName', Config::get('community_store.emailalertsname'), ['placeholder' => t('From Name')]); ?>
                             </div>
                         </div>
                     </div>
 
-                    <h3><?= t('Receipt Emails'); ?></h3>
+                    <h3><?php echo t('Receipt Emails'); ?></h3>
 
                     <div class="form-group">
-                        <label><?= t("Receipt Email Header Content"); ?></label>
+                        <label><?php echo t("Receipt Email Header Content"); ?></label>
                         <?php $editor = \Core::make('editor');
                         echo $editor->outputStandardEditor('receiptHeader', Config::get('community_store.receiptHeader')); ?>
                     </div>
 
                     <div class="form-group">
-                        <label><?= t("Receipt Email Footer Content"); ?></label>
+                        <label><?php echo t("Receipt Email Footer Content"); ?></label>
                         <?php $editor = \Core::make('editor');
                         echo $editor->outputStandardEditor('receiptFooter', Config::get('community_store.receiptFooter')); ?>
                     </div>
@@ -275,189 +276,192 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
                 <!-- #settings-products -->
                 <div class="col-sm-9 store-pane" id="settings-products">
-                    <h3><?= t("Products"); ?></h3>
+                    <h3><?php echo t("Products"); ?></h3>
                     <div class="form-group">
-                        <?= $form->label('productPublishTarget', t('Page to Publish Product Pages Under')); ?>
-                        <?= $pageSelector->selectPage('productPublishTarget', $productPublishTarget); ?>
+                        <?php echo $form->label('productPublishTarget', t('Page to Publish Product Pages Under')); ?>
+                        <?php echo $pageSelector->selectPage('productPublishTarget', $productPublishTarget); ?>
                     </div>
+                </div>
 
-                    <h3><?= t("Product Images"); ?></h3>
+                <!-- #settings-product-images -->
+                <div class="col-sm-9 store-pane" id="settings-product-images">
+                    <h3><?php echo t("Product Images"); ?></h3>
 
                     <div class="row">
-                        <h4 class="col-md-12"><?= t("Product Thumbnail Types"); ?></h4>
-                        <div class="form-group col-md-4">
-                            <?= $form->label('defaultSingleProductThumbType', t('Single Product Thumbnail Type')); ?>
-                            <?= $form->select('defaultSingleProductThumbType', $thumbnailTypes, Config::get('community_store.defaultSingleProductThumbType')); ?>
+                        <h4 class="col-md-12"><?php echo t("Product Thumbnail Types"); ?></h4>
+                        <div class="form-group col-md-12">
+                            <?php echo $form->label('defaultSingleProductThumbType', t('Single Product Thumbnail Type')); ?>
+                            <?php echo $form->select('defaultSingleProductThumbType', $thumbnailTypes, Config::get('community_store.defaultSingleProductThumbType')); ?>
                         </div>
 
-                        <div class="form-group col-md-4">
-                            <?= $form->label('defaultProductListThumbType', t('Product List Thumbnail Type')); ?>
-                            <?= $form->select('defaultProductListThumbType', $thumbnailTypes, Config::get('community_store.defaultProductListThumbType')); ?>
+                        <div class="form-group col-md-12">
+                            <?php echo $form->label('defaultProductListThumbType', t('Product List Thumbnail Type')); ?>
+                            <?php echo $form->select('defaultProductListThumbType', $thumbnailTypes, Config::get('community_store.defaultProductListThumbType')); ?>
                         </div>
 
-                        <div class="form-group col-md-4">
-                            <?= $form->label('defaultProductModalThumbType', t('Product Modal Thumbnail Type')); ?>
-                            <?= $form->select('defaultProductModalThumbType', $thumbnailTypes, Config::get('community_store.defaultProductModalThumbType')); ?>
-                        </div>
-                    </div>
-
-                    <div class="row">
-                        <h4 class="col-md-12"><?= t("Single Product - Legacy Thumbnail Generator"); ?></h4>
-                        <div class="form-group col-md-4">
-                            <?= $form->label('defaultSingleProductImageWidth', t('Image Width')); ?>
-                            <div class="input-group">
-                                <?= $form->number('defaultSingleProductImageWidth', Config::get('community_store.defaultSingleProductImageWidth') ?: Image::DEFAULT_SINGLE_PRODUCT_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
-                                <div class="input-group-addon">px</div>
-                            </div>
-                            <div class="help-block">
-                                <?= t("Default value: %s", Image::DEFAULT_SINGLE_PRODUCT_IMG_WIDTH); ?>
-                            </div>
-                        </div>
-
-                        <div class="form-group col-md-4">
-                            <?= $form->label('defaultSingleProductImageHeight', t('Image Height')); ?>
-                            <div class="input-group">
-                                <?= $form->number('defaultSingleProductImageHeight', Config::get('community_store.defaultSingleProductImageHeight') ?: Image::DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
-                                <div class="input-group-addon">px</div>
-                            </div>
-                            <div class="help-block">
-                                <?= t("Default value: %s", Image::DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT); ?>
-                            </div>
-                        </div>
-
-                        <div class="form-group col-md-4">
-                            <?= $form->label('defaultSingleProductCrop', t('Image cropping')); ?>
-                            <?= $form->select('defaultSingleProductCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultSingleProductCrop')); ?>
+                        <div class="form-group col-md-12">
+                            <?php echo $form->label('defaultProductModalThumbType', t('Product Modal Thumbnail Type')); ?>
+                            <?php echo $form->select('defaultProductModalThumbType', $thumbnailTypes, Config::get('community_store.defaultProductModalThumbType')); ?>
                         </div>
                     </div>
 
                     <div class="row">
-                        <h4 class="col-md-12"><?= t("Product List - Legacy Thumbnail Generator"); ?></h4>
+                        <h4 class="col-md-12"><?php echo t("Single Product - Legacy Thumbnail Generator"); ?></h4>
                         <div class="form-group col-md-4">
-                            <?= $form->label('defaultProductListImageWidth', t('Image Width')); ?>
+                            <?php echo $form->label('defaultSingleProductImageWidth', t('Image Width')); ?>
                             <div class="input-group">
-                                <?= $form->number('defaultProductListImageWidth', Config::get('community_store.defaultProductListImageWidth') ?: Image::DEFAULT_PRODUCT_LIST_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
+                                <?php echo $form->number('defaultSingleProductImageWidth', Config::get('community_store.defaultSingleProductImageWidth') ?: Image::DEFAULT_SINGLE_PRODUCT_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
                                 <div class="input-group-addon">px</div>
                             </div>
                             <div class="help-block">
-                                <?= t("Default value: %s", Image::DEFAULT_PRODUCT_LIST_IMG_WIDTH); ?>
+                                <?php echo t("Default value: %s", Image::DEFAULT_SINGLE_PRODUCT_IMG_WIDTH); ?>
                             </div>
                         </div>
 
                         <div class="form-group col-md-4">
-                            <?= $form->label('defaultProductListImageHeight', t('Image Height')); ?>
+                            <?php echo $form->label('defaultSingleProductImageHeight', t('Image Height')); ?>
                             <div class="input-group">
-                                <?= $form->number('defaultProductListImageHeight', Config::get('community_store.defaultProductListImageHeight') ?: Image::DEFAULT_PRODUCT_LIST_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
+                                <?php echo $form->number('defaultSingleProductImageHeight', Config::get('community_store.defaultSingleProductImageHeight') ?: Image::DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
                                 <div class="input-group-addon">px</div>
                             </div>
                             <div class="help-block">
-                                <?= t("Default value: %s", Image::DEFAULT_PRODUCT_LIST_IMG_HEIGHT); ?>
+                                <?php echo t("Default value: %s", Image::DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT); ?>
                             </div>
                         </div>
 
                         <div class="form-group col-md-4">
-                            <?= $form->label('defaultProductListCrop', t('Image cropping')); ?>
-                            <?= $form->select('defaultProductListCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultProductListCrop')); ?>
+                            <?php echo $form->label('defaultSingleProductCrop', t('Image cropping')); ?>
+                            <?php echo $form->select('defaultSingleProductCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultSingleProductCrop')); ?>
                         </div>
                     </div>
 
                     <div class="row">
-                        <h4 class="col-md-12"><?= t("Product Modal - Legacy Thumbnail Generator"); ?></h4>
+                        <h4 class="col-md-12"><?php echo t("Product List - Legacy Thumbnail Generator"); ?></h4>
                         <div class="form-group col-md-4">
-                            <?= $form->label('defaultProductModalImageWidth', t('Image Width')); ?>
+                            <?php echo $form->label('defaultProductListImageWidth', t('Image Width')); ?>
                             <div class="input-group">
-                                <?= $form->number('defaultProductModalImageWidth', Config::get('community_store.defaultProductModalImageWidth') ?: Image::DEFAULT_PRODUCT_MODAL_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
+                                <?php echo $form->number('defaultProductListImageWidth', Config::get('community_store.defaultProductListImageWidth') ?: Image::DEFAULT_PRODUCT_LIST_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
                                 <div class="input-group-addon">px</div>
                             </div>
                             <div class="help-block">
-                                <?= t("Default value: %s", Image::DEFAULT_PRODUCT_MODAL_IMG_WIDTH); ?>
+                                <?php echo t("Default value: %s", Image::DEFAULT_PRODUCT_LIST_IMG_WIDTH); ?>
                             </div>
                         </div>
 
                         <div class="form-group col-md-4">
-                            <?= $form->label('defaultProductModalImageHeight', t('Image Height')); ?>
+                            <?php echo $form->label('defaultProductListImageHeight', t('Image Height')); ?>
                             <div class="input-group">
-                                <?= $form->number('defaultProductModalImageHeight', Config::get('community_store.defaultProductModalImageHeight') ?: Image::DEFAULT_PRODUCT_MODAL_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
+                                <?php echo $form->number('defaultProductListImageHeight', Config::get('community_store.defaultProductListImageHeight') ?: Image::DEFAULT_PRODUCT_LIST_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
                                 <div class="input-group-addon">px</div>
                             </div>
                             <div class="help-block">
-                                <?= t("Default value: %s", Image::DEFAULT_PRODUCT_MODAL_IMG_HEIGHT); ?>
+                                <?php echo t("Default value: %s", Image::DEFAULT_PRODUCT_LIST_IMG_HEIGHT); ?>
                             </div>
                         </div>
 
                         <div class="form-group col-md-4">
-                            <?= $form->label('defaultProductModalCrop', t('Image cropping')); ?>
-                            <?= $form->select('defaultProductModalCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultProductModalCrop')); ?>
+                            <?php echo $form->label('defaultProductListCrop', t('Image cropping')); ?>
+                            <?php echo $form->select('defaultProductListCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultProductListCrop')); ?>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <h4 class="col-md-12"><?php echo t("Product Modal - Legacy Thumbnail Generator"); ?></h4>
+                        <div class="form-group col-md-4">
+                            <?php echo $form->label('defaultProductModalImageWidth', t('Image Width')); ?>
+                            <div class="input-group">
+                                <?php echo $form->number('defaultProductModalImageWidth', Config::get('community_store.defaultProductModalImageWidth') ?: Image::DEFAULT_PRODUCT_MODAL_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                            <div class="help-block">
+                                <?php echo t("Default value: %s", Image::DEFAULT_PRODUCT_MODAL_IMG_WIDTH); ?>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-4">
+                            <?php echo $form->label('defaultProductModalImageHeight', t('Image Height')); ?>
+                            <div class="input-group">
+                                <?php echo $form->number('defaultProductModalImageHeight', Config::get('community_store.defaultProductModalImageHeight') ?: Image::DEFAULT_PRODUCT_MODAL_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                            <div class="help-block">
+                                <?php echo t("Default value: %s", Image::DEFAULT_PRODUCT_MODAL_IMG_HEIGHT); ?>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-4">
+                            <?php echo $form->label('defaultProductModalCrop', t('Image cropping')); ?>
+                            <?php echo $form->select('defaultProductModalCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultProductModalCrop')); ?>
                         </div>
                     </div>
                 </div>
 
                 <!-- #settings-customers -->
                 <div class="col-sm-9 store-pane" id="settings-checkout">
-                    <h3><?= t('Cart and Checkout'); ?></h3>
+                    <h3><?php echo t('Cart and Checkout'); ?></h3>
                     <div class="form-group">
                         <?php $shoppingDisabled = Config::get('community_store.shoppingDisabled');
                         ?>
-                        <label><?= $form->radio('shoppingDisabled', ' ', ('' == $shoppingDisabled)); ?> <?php  echo t('Enabled'); ?></label><br />
-                        <label><?= $form->radio('shoppingDisabled', 'all', 'all' == $shoppingDisabled); ?> <?php  echo t('Disabled (Catalog Mode)'); ?></label><br />
+                        <label><?php echo $form->radio('shoppingDisabled', ' ', ('' == $shoppingDisabled)); ?> <?php  echo t('Enabled'); ?></label><br />
+                        <label><?php echo $form->radio('shoppingDisabled', 'all', 'all' == $shoppingDisabled); ?> <?php  echo t('Disabled (Catalog Mode)'); ?></label><br />
                     </div>
 
-                    <h3><?= t('Guest Checkout'); ?></h3>
+                    <h3><?php echo t('Guest Checkout'); ?></h3>
                     <div class="form-group">
                         <?php $guestCheckout = Config::get('community_store.guestCheckout');
                         $guestCheckout = ($guestCheckout ? $guestCheckout : 'off');
                         ?>
-                        <label><?= $form->radio('guestCheckout', 'always', 'always' == $guestCheckout); ?> <?php  echo t('Always (unless login required for products in cart)'); ?></label><br />
-                        <label><?= $form->radio('guestCheckout', 'option', 'option' == $guestCheckout); ?> <?php  echo t('Offer as checkout option'); ?></label><br />
-                        <label><?= $form->radio('guestCheckout', 'off', 'off' == $guestCheckout || '' == $guestCheckout); ?> <?php  echo t('Disabled'); ?></label><br />
+                        <label><?php echo $form->radio('guestCheckout', 'always', 'always' == $guestCheckout); ?> <?php  echo t('Always (unless login required for products in cart)'); ?></label><br />
+                        <label><?php echo $form->radio('guestCheckout', 'option', 'option' == $guestCheckout); ?> <?php  echo t('Offer as checkout option'); ?></label><br />
+                        <label><?php echo $form->radio('guestCheckout', 'off', 'off' == $guestCheckout || '' == $guestCheckout); ?> <?php  echo t('Disabled'); ?></label><br />
                     </div>
 
-                    <h3><?= t('Address Auto-Complete'); ?></h3>
+                    <h3><?php echo t('Address Auto-Complete'); ?></h3>
                     <div class="form-group">
-                        <?= $form->label('placesAPIKey', t('Address Auto-Complete API Key (Google Places)')); ?>
-                        <?= $form->text('placesAPIKey', Config::get('community_store.placesAPIKey')); ?>
+                        <?php echo $form->label('placesAPIKey', t('Address Auto-Complete API Key (Google Places)')); ?>
+                        <?php echo $form->text('placesAPIKey', Config::get('community_store.placesAPIKey')); ?>
                     </div>
 
-                    <h3><?= t('Company Name'); ?></h3>
+                    <h3><?php echo t('Company Name'); ?></h3>
                     <div class="form-group">
                         <?php $companyField = Config::get('community_store.companyField');
                         $companyField = ($companyField ? $companyField : 'off');
                         ?>
-                        <label><?= $form->radio('companyField', 'off', 'off' == $companyField || '' == $companyField); ?> <?php  echo t('Hidden'); ?></label><br />
-                        <label><?= $form->radio('companyField', 'optional', 'optional' == $companyField); ?> <?php  echo t('Optional'); ?></label><br />
-                        <label><?= $form->radio('companyField', 'required', 'required' == $companyField); ?> <?php  echo t('Required'); ?></label><br />
+                        <label><?php echo $form->radio('companyField', 'off', 'off' == $companyField || '' == $companyField); ?> <?php  echo t('Hidden'); ?></label><br />
+                        <label><?php echo $form->radio('companyField', 'optional', 'optional' == $companyField); ?> <?php  echo t('Optional'); ?></label><br />
+                        <label><?php echo $form->radio('companyField', 'required', 'required' == $companyField); ?> <?php  echo t('Required'); ?></label><br />
                     </div>
 
-                    <h3><?= t('Billing Details'); ?></h3>
+                    <h3><?php echo t('Billing Details'); ?></h3>
 
                     <div class="row">
                         <div class="col-xs-12">
-                            <label><?= $form->checkbox('noBillingSave', '1', Config::get('community_store.noBillingSave') ? '1' : '0'); ?>
-                                <?= t('Do not save billing details to user on order'); ?></label>
+                            <label><?php echo $form->checkbox('noBillingSave', '1', Config::get('community_store.noBillingSave') ? '1' : '0'); ?>
+                                <?php echo t('Do not save billing details to user on order'); ?></label>
                         </div>
                     </div>
 
                     <div class="row">
                         <div class="col-xs-12">
                             <div class="ccm-search-field-content ccm-search-field-content-select2">
-                                <?= t('For users in groups'); ?> <?php echo $form->selectMultiple('noBillingSaveGroups', $groupList, explode(',', Config::get('community_store.noBillingSaveGroups')), ['class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('All Users/Groups')]); ?>
+                                <?php echo t('For users in groups'); ?> <?php echo $form->selectMultiple('noBillingSaveGroups', $groupList, explode(',', Config::get('community_store.noBillingSaveGroups')), ['class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('All Users/Groups')]); ?>
                             </div>
                         </div>
                     </div>
 
 
-                    <h3><?= t('Shipping Details'); ?></h3>
+                    <h3><?php echo t('Shipping Details'); ?></h3>
                     <div class="row">
                         <div class="col-xs-12">
-                            <label><?= $form->checkbox('noShippingSave', '1', Config::get('community_store.noShippingSave') ? '1' : '0'); ?>
-                                <?= t('Do not save shipping details to user on order'); ?></label>
+                            <label><?php echo $form->checkbox('noShippingSave', '1', Config::get('community_store.noShippingSave') ? '1' : '0'); ?>
+                                <?php echo t('Do not save shipping details to user on order'); ?></label>
                         </div>
                     </div>
 
                     <div class="row">
                         <div class="col-xs-12">
                             <div class="ccm-search-field-content ccm-search-field-content-select2">
-                                <?= t('For users in groups'); ?> <?php echo $form->selectMultiple('noShippingSaveGroups', $groupList, explode(',', Config::get('community_store.noShippingSaveGroups')), ['class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('All Users/Groups')]); ?>
+                                <?php echo t('For users in groups'); ?> <?php echo $form->selectMultiple('noShippingSaveGroups', $groupList, explode(',', Config::get('community_store.noShippingSaveGroups')), ['class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('All Users/Groups')]); ?>
                             </div>
                         </div>
                     </div>
@@ -471,12 +475,12 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                         });
                     </script>
 
-                    <h3><?= t('Digital Download Expiry'); ?></h3>
+                    <h3><?php echo t('Digital Download Expiry'); ?></h3>
                     <div class="form-group">
-                        <?= $form->label('download_expiry_hours', t('Number of hours before digital download links expiry')); ?>
+                        <?php echo $form->label('download_expiry_hours', t('Number of hours before digital download links expiry')); ?>
                         <div class="input-group">
-                        <?= $form->number('download_expiry_hours', Config::get('community_store.download_expiry_hours'), ['placeholder' => '48']); ?>
-                        <div class="input-group-addon"><?= t('hours'); ?></div>
+                        <?php echo $form->number('download_expiry_hours', Config::get('community_store.download_expiry_hours'), ['placeholder' => '48']); ?>
+                        <div class="input-group-addon"><?php echo t('hours'); ?></div>
                         </div>
                     </div>
 
@@ -485,10 +489,10 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
                 <!-- #settings-orders -->
                 <div class="col-sm-9 store-pane" id="settings-orders">
-                    <h3><?= t('Orders'); ?></h3>
+                    <h3><?php echo t('Orders'); ?></h3>
                     <div class="form-group">
-                        <label><?= $form->checkbox('showUnpaidExternalPaymentOrders', '1', Config::get('community_store.showUnpaidExternalPaymentOrders') ? '1' : '0'); ?>
-                            <?= t('Unhide orders with incomplete payments (i.e. cancelled Paypal transactions)'); ?></label></div>
+                        <label><?php echo $form->checkbox('showUnpaidExternalPaymentOrders', '1', Config::get('community_store.showUnpaidExternalPaymentOrders') ? '1' : '0'); ?>
+                            <?php echo t('Unhide orders with incomplete payments (i.e. cancelled Paypal transactions)'); ?></label></div>
 
                 </div>
 
@@ -496,7 +500,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
     	    <div class="ccm-dashboard-form-actions-wrapper">
     	        <div class="ccm-dashboard-form-actions">
-    	            <button class="pull-right btn btn-success" type="submit" ><?= t('Save Settings'); ?></button>
+    	            <button class="pull-right btn btn-success" type="submit" ><?php echo t('Save Settings'); ?></button>
     	        </div>
     	    </div>
 

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -1,52 +1,52 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
 	    <div class="ccm-dashboard-header-buttons">
-            <a href="<?= \URL::to('/dashboard/store/settings/shipping')?>" class="btn btn-primary"><i class="fa fa-truck"></i> <?= t("Shipping Methods")?></a>
-            <a href="<?= \URL::to('/dashboard/store/settings/tax')?>" class="btn btn-primary"><i class="fa fa-money"></i> <?= t("Tax Rates")?></a>
+            <a href="<?= \URL::to('/dashboard/store/settings/shipping'); ?>" class="btn btn-primary"><i class="fa fa-truck"></i> <?= t("Shipping Methods"); ?></a>
+            <a href="<?= \URL::to('/dashboard/store/settings/tax'); ?>" class="btn btn-primary"><i class="fa fa-money"></i> <?= t("Tax Rates"); ?></a>
         </div>
 
-	    <form method="post" action="<?= $view->action('save')?>">
+	    <form method="post" action="<?= $view->action('save'); ?>">
             <?= $token->output('community_store'); ?>
 
             <div class="row">
                 <div class="col-sm-3">
 
                     <ul class="nav nav-pills nav-stacked">
-                            <li class="active"><a href="#settings-currency" data-pane-toggle ><?= t('Currency')?></a></li>
-                            <li><a href="#settings-tax" data-pane-toggle><?= t('Tax')?></a></li>
-                            <li><a href="#settings-shipping" data-pane-toggle><?= t('Shipping')?></a></li>
-                            <li><a href="#settings-payments" data-pane-toggle><?= t('Payments')?></a></li>
-                            <li><a href="#settings-order-statuses" data-pane-toggle><?= t('Fulfilment Statuses')?></a></li>
-                            <li><a href="#settings-notifications" data-pane-toggle><?= t('Notifications and Receipts')?></a></li>
-                            <li><a href="#settings-products" data-pane-toggle><?= t('Products')?></a></li>
-                            <li><a href="#settings-checkout" data-pane-toggle><?= t('Cart and Checkout')?></a></li>
-                            <li><a href="#settings-orders" data-pane-toggle><?= t('Orders')?></a></li>
+                            <li class="active"><a href="#settings-currency" data-pane-toggle ><?= t('Currency'); ?></a></li>
+                            <li><a href="#settings-tax" data-pane-toggle><?= t('Tax'); ?></a></li>
+                            <li><a href="#settings-shipping" data-pane-toggle><?= t('Shipping'); ?></a></li>
+                            <li><a href="#settings-payments" data-pane-toggle><?= t('Payments'); ?></a></li>
+                            <li><a href="#settings-order-statuses" data-pane-toggle><?= t('Fulfilment Statuses'); ?></a></li>
+                            <li><a href="#settings-notifications" data-pane-toggle><?= t('Notifications and Receipts'); ?></a></li>
+                            <li><a href="#settings-products" data-pane-toggle><?= t('Products'); ?></a></li>
+                            <li><a href="#settings-checkout" data-pane-toggle><?= t('Cart and Checkout'); ?></a></li>
+                            <li><a href="#settings-orders" data-pane-toggle><?= t('Orders'); ?></a></li>
                         </ul>
 
                 </div>
 
                 <div class="col-sm-9 store-pane active" id="settings-currency">
-                    <h3><?= t('Currency Settings');?></h3>
+                    <h3><?= t('Currency Settings'); ?></h3>
                     <div class="row">
                         <div class="form-group col-md-6">
-                            <?= $form->label('symbol',t('Currency Symbol')); ?>
-                            <?= $form->text('symbol',Config::get('community_store.symbol'));?>
+                            <?= $form->label('symbol', t('Currency Symbol')); ?>
+                            <?= $form->text('symbol', Config::get('community_store.symbol')); ?>
                         </div>
 
                         <div class="form-group col-md-6">
-                            <?= $form->label('currency',t('Currency Code')); ?>
-                            <?= $form->text('currency',Config::get('community_store.currency'));?>
+                            <?= $form->label('currency', t('Currency Code')); ?>
+                            <?= $form->text('currency', Config::get('community_store.currency')); ?>
                         </div>
                     </div>
                     <div class="row">
                         <div class="form-group col-md-6">
-                            <?= $form->label('thousand',t('Thousands Separator')); ?>
-                            <?= $form->text('thousand',Config::get('community_store.thousand'));?>
+                            <?= $form->label('thousand', t('Thousands Separator')); ?>
+                            <?= $form->text('thousand', Config::get('community_store.thousand')); ?>
                             <span class="help-block"><?= t('e.g. , or a space'); ?></span>
                         </div>
                         <div class="form-group col-md-6">
-                            <?= $form->label('whole',t('Whole Number Separator')); ?>
-                            <?= $form->text('whole',Config::get('community_store.whole')); ?>
+                            <?= $form->label('whole', t('Whole Number Separator')); ?>
+                            <?= $form->text('whole', Config::get('community_store.whole')); ?>
                             <span class="help-block"><?= t('e.g. period or a comma'); ?></span>
                         </div>
                     </div>
@@ -54,52 +54,52 @@
                 </div><!-- #settings-currency -->
 
                 <div class="col-sm-9 store-pane" id="settings-tax">
-                    <h3><?= t('Tax Settings');?></h3>
+                    <h3><?= t('Tax Settings'); ?></h3>
 
                     <div class="form-group">
-                        <label for="calculation"><?= t("Are Prices Entered with Tax Included?")?></label>
-                        <?= $form->select('calculation',array('add'=>t("No, I will enter product prices EXCLUSIVE of tax"),'extract'=>t("Yes, I will enter product prices INCLUSIVE of tax")),Config::get('community_store.calculation')); ?>
+                        <label for="calculation"><?= t("Are Prices Entered with Tax Included?"); ?></label>
+                        <?= $form->select('calculation', ['add' => t("No, I will enter product prices EXCLUSIVE of tax"), 'extract' => t("Yes, I will enter product prices INCLUSIVE of tax")], Config::get('community_store.calculation')); ?>
                     </div>
 
                     <div class="form-group">
-                        <label for="vat_number"><?= t("Enable EU VAT Number Options?")?></label>
-                        <?= $form->select('vat_number',array('0'=>t("No, I don't need this"),'1'=>t("Yes, enable VAT Number options")),Config::get('community_store.vat_number')); ?>
+                        <label for="vat_number"><?= t("Enable EU VAT Number Options?"); ?></label>
+                        <?= $form->select('vat_number', ['0' => t("No, I don't need this"), '1' => t("Yes, enable VAT Number options")], Config::get('community_store.vat_number')); ?>
                     </div>
 
                 </div>
 
                 <div class="col-sm-9 store-pane" id="settings-shipping">
 
-                    <h3><?= t("Shipping Units")?></h3>
+                    <h3><?= t("Shipping Units"); ?></h3>
                     <div class="row">
                         <div class="col-xs-6">
                             <div class="form-group">
-                                <?= $form->label('weightUnit',t('Units for Weight'));?>
-                                <?php // do not add other units to this list. these are specific to making calculated shipping work ?>
-                                <?= $form->select('weightUnit',array('oz'=>t('oz'),'lb'=>t('lb'),'kg'=>t('kg'),'g'=>t('g')),Config::get('community_store.weightUnit'));?>
+                                <?= $form->label('weightUnit', t('Units for Weight')); ?>
+                                <?php // do not add other units to this list. these are specific to making calculated shipping work?>
+                                <?= $form->select('weightUnit', ['oz' => t('oz'), 'lb' => t('lb'), 'kg' => t('kg'), 'g' => t('g')], Config::get('community_store.weightUnit')); ?>
                             </div>
                         </div>
                         <div class="col-xs-6">
                             <div class="form-group">
-                                <?= $form->label('sizeUnit',t('Units for Size'));?>
-                                <?php // do not add other units to this list. these are specific to making calculated shipping work ?>
-                                <?= $form->select('sizeUnit',array('in'=>t('in'),'cm'=>t('cm'),'mm'=>t('mm')),Config::get('community_store.sizeUnit'));?>
+                                <?= $form->label('sizeUnit', t('Units for Size')); ?>
+                                <?php // do not add other units to this list. these are specific to making calculated shipping work?>
+                                <?= $form->select('sizeUnit', ['in' => t('in'), 'cm' => t('cm'), 'mm' => t('mm')], Config::get('community_store.sizeUnit')); ?>
                             </div>
                         </div>
                     </div>
 
                     <div class="row">
                         <div class="col-xs-12">
-                            <label><?= $form->checkbox('deliveryInstructions', '1',Config::get('community_store.deliveryInstructions') ? '1' : '0')?>
-                                <?= t('Include Delivery Instructions field in checkout');?></label>
+                            <label><?= $form->checkbox('deliveryInstructions', '1', Config::get('community_store.deliveryInstructions') ? '1' : '0'); ?>
+                                <?= t('Include Delivery Instructions field in checkout'); ?></label>
                         </div>
                     </div>
 
-                    <h3><?= t("Multiple Packages Support")?></h3>
+                    <h3><?= t("Multiple Packages Support"); ?></h3>
                     <div class="row">
                         <div class="col-xs-12">
-                            <label><?= $form->checkbox('multiplePackages', '1',Config::get('community_store.multiplePackages') ? '1' : '0')?>
-                                <?= t('Enable Package(s) Data fields');?></label>
+                            <label><?= $form->checkbox('multiplePackages', '1', Config::get('community_store.multiplePackages') ? '1' : '0'); ?>
+                                <?= t('Enable Package(s) Data fields'); ?></label>
                             <span class="help-block">Allows multiple packages to be defined per product configuration, to be used by advanced shipping methods</span>
                         </div>
                     </div>
@@ -109,40 +109,39 @@
                 </div><!-- #settings-shipping -->
 
                 <div class="col-sm-9 store-pane" id="settings-payments">
-                    <h3><?= t("Payment Methods")?></h3>
+                    <h3><?= t("Payment Methods"); ?></h3>
                     <?php
-                        if($installedPaymentMethods){
-                            foreach($installedPaymentMethods as $pm){?>
+                        if ($installedPaymentMethods) {
+                            foreach ($installedPaymentMethods as $pm) {
+                                ?>
 
                             <div class="panel panel-default">
 
-                                <div class="panel-heading"><?= t($pm->getName())?></div>
+                                <div class="panel-heading"><?= t($pm->getName()); ?></div>
                                 <div class="panel-body">
                                     <div class="form-group paymentMethodEnabled">
-                                        <input type="hidden" name="paymentMethodHandle[<?= $pm->getID()?>]" value="<?= $pm->getHandle()?>">
-                                        <label><?= t("Enabled")?></label>
+                                        <input type="hidden" name="paymentMethodHandle[<?= $pm->getID(); ?>]" value="<?= $pm->getHandle(); ?>">
+                                        <label><?= t("Enabled"); ?></label>
                                         <?php
-                                            echo $form->select("paymentMethodEnabled[".$pm->getID()."]", array(0=>t("No"),1=>t("Yes")),$pm->isEnabled());
-                                        ?>
+                                            echo $form->select("paymentMethodEnabled[" . $pm->getID() . "]", [0 => t("No"), 1 => t("Yes")], $pm->isEnabled()); ?>
                                     </div>
-                                    <div id="paymentMethodForm-<?= $pm->getID(); ?>" style="display:<?= $pm->isEnabled() ? 'block':'none'; ?>">
+                                    <div id="paymentMethodForm-<?= $pm->getID(); ?>" style="display:<?= $pm->isEnabled() ? 'block' : 'none'; ?>">
                                         <div class="row">
                                             <div class="form-group col-sm-6">
-                                                <label><?= t("Display Name (on checkout)")?></label>
-                                                <?= $form->text('paymentMethodDisplayName['.$pm->getID().']',$pm->getDisplayName()); ?>
+                                                <label><?= t("Display Name (on checkout)"); ?></label>
+                                                <?= $form->text('paymentMethodDisplayName[' . $pm->getID() . ']', $pm->getDisplayName()); ?>
                                             </div>
                                             <div class="form-group col-sm-6">
-                                                <label><?= t("Button Label")?></label>
-                                                <?= $form->text('paymentMethodButtonLabel['.$pm->getID().']',$pm->getButtonLabel(), array('placeholder'=>t('Optional'))); ?>
+                                                <label><?= t("Button Label"); ?></label>
+                                                <?= $form->text('paymentMethodButtonLabel[' . $pm->getID() . ']', $pm->getButtonLabel(), ['placeholder' => t('Optional')]); ?>
                                             </div>
                                         </div>
                                         <div class="form-group">
-                                            <label><?= t("Sort Order")?></label>
-                                            <?= $form->text('paymentMethodSortOrder['.$pm->getID().']',$pm->getSortOrder()); ?>
+                                            <label><?= t("Sort Order"); ?></label>
+                                            <?= $form->text('paymentMethodSortOrder[' . $pm->getID() . ']', $pm->getSortOrder()); ?>
                                         </div>
                                         <?php
-                                            $pm->renderDashboardForm();
-                                        ?>
+                                            $pm->renderDashboardForm(); ?>
                                     </div>
 
                                 </div>
@@ -171,9 +170,10 @@
                 </div><!-- #settings-payments -->
 
                 <div class="col-sm-9 store-pane" id="settings-order-statuses">
-                    <h3><?= t("Fulfilment Statuses")?></h3>
+                    <h3><?= t("Fulfilment Statuses"); ?></h3>
                     <?php
-                    if(count($orderStatuses)>0){ ?>
+                    if (count($orderStatuses) > 0) {
+                        ?>
                         <div class="panel panel-default">
 
                             <table class="table" id="orderStatusTable">
@@ -190,15 +190,17 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                <?php foreach($orderStatuses as $orderStatus){?>
+                                <?php foreach ($orderStatuses as $orderStatus) {
+                            ?>
                                     <tr>
                                         <td class="sorthandle"><input type="hidden" name="osID[]" value="<?= $orderStatus->getID(); ?>"><i class="fa fa-arrows-v"></i></td>
                                         <td><input type="text" name="osName[]" value="<?= t($orderStatus->getName()); ?>" placeholder="<?= $orderStatus->getReadableHandle(); ?>" class="form-control ccm-input-text"></td>
-                                        <td><input type="radio" name="osIsStartingStatus" value="<?= $orderStatus->getID(); ?>" <?= $orderStatus->isStartingStatus() ? 'checked':''; ?>></td>
-                                        <td style="display:none;"><input type="checkbox" name="osInformSite[]" value="1" <?= $orderStatus->getInformSite() ? 'checked':''; ?> class="form-control"></td>
-                                        <td style="display:none;"><input type="checkbox" name="osInformCustomer[]" value="1" <?= $orderStatus->getInformCustomer() ? 'checked':''; ?> class="form-control"></td>
+                                        <td><input type="radio" name="osIsStartingStatus" value="<?= $orderStatus->getID(); ?>" <?= $orderStatus->isStartingStatus() ? 'checked' : ''; ?>></td>
+                                        <td style="display:none;"><input type="checkbox" name="osInformSite[]" value="1" <?= $orderStatus->getInformSite() ? 'checked' : ''; ?> class="form-control"></td>
+                                        <td style="display:none;"><input type="checkbox" name="osInformCustomer[]" value="1" <?= $orderStatus->getInformCustomer() ? 'checked' : ''; ?> class="form-control"></td>
                                     </tr>
-                                <?php } ?>
+                                <?php
+                        } ?>
                                 </tbody>
                             </table>
                             <script>
@@ -225,44 +227,44 @@
                 </div><!-- #settings-order-statuses -->
 
                 <div class="col-sm-9 store-pane" id="settings-notifications">
-                    <h3><?= t('Notification Emails');?></h3>
+                    <h3><?= t('Notification Emails'); ?></h3>
 
                     <div class="form-group">
-                        <?= $form->label('notificationEmails',t('Send order notification to email')); ?>
-                        <?= $form->text('notificationEmails',Config::get('community_store.notificationemails'), array('placeholder'=>t('Email Address')));?>
+                        <?= $form->label('notificationEmails', t('Send order notification to email')); ?>
+                        <?= $form->text('notificationEmails', Config::get('community_store.notificationemails'), ['placeholder' => t('Email Address')]); ?>
                         <span class="help-block"><?= t('separate multiple emails with commas'); ?></span>
                     </div>
 
-                    <h4><?= t('Emails Sent From');?></h4>
+                    <h4><?= t('Emails Sent From'); ?></h4>
 
                     <div class="row">
                         <div class="col-xs-6">
                             <div class="form-group">
-                                <?= $form->label('emailAlert',t('From Email'));?>
-                                <?= $form->text('emailAlert',Config::get('community_store.emailalerts'),array('placeholder'=>t('From Email Address'))); ?>
+                                <?= $form->label('emailAlert', t('From Email')); ?>
+                                <?= $form->text('emailAlert', Config::get('community_store.emailalerts'), ['placeholder' => t('From Email Address')]); ?>
                             </div>
                         </div>
 
                         <div class="col-xs-6">
                             <div class="form-group">
-                                <?= $form->label('emailAlertName',t('From Name'));?>
-                                <?= $form->text('emailAlertName',Config::get('community_store.emailalertsname'),array('placeholder'=>t('From Name'))); ?>
+                                <?= $form->label('emailAlertName', t('From Name')); ?>
+                                <?= $form->text('emailAlertName', Config::get('community_store.emailalertsname'), ['placeholder' => t('From Name')]); ?>
                             </div>
                         </div>
                     </div>
 
-                    <h3><?= t('Receipt Emails');?></h3>
+                    <h3><?= t('Receipt Emails'); ?></h3>
 
                     <div class="form-group">
-                        <label><?= t("Receipt Email Header Content")?></label>
+                        <label><?= t("Receipt Email Header Content"); ?></label>
                         <?php $editor = \Core::make('editor');
-                        echo $editor->outputStandardEditor('receiptHeader', Config::get('community_store.receiptHeader'));?>
+                        echo $editor->outputStandardEditor('receiptHeader', Config::get('community_store.receiptHeader')); ?>
                     </div>
 
                     <div class="form-group">
-                        <label><?= t("Receipt Email Footer Content")?></label>
+                        <label><?= t("Receipt Email Footer Content"); ?></label>
                         <?php $editor = \Core::make('editor');
-                        echo $editor->outputStandardEditor('receiptFooter', Config::get('community_store.receiptFooter'));?>
+                        echo $editor->outputStandardEditor('receiptFooter', Config::get('community_store.receiptFooter')); ?>
                     </div>
 
 
@@ -270,80 +272,122 @@
 
                 <!-- #settings-products -->
                 <div class="col-sm-9 store-pane" id="settings-products">
-                    <h3><?= t("Products")?></h3>
+                    <h3><?= t("Products"); ?></h3>
                     <div class="form-group">
-                        <?= $form->label('productPublishTarget',t('Page to Publish Product Pages Under'));?>
-                        <?= $pageSelector->selectPage('productPublishTarget',$productPublishTarget)?>
+                        <?= $form->label('productPublishTarget', t('Page to Publish Product Pages Under')); ?>
+                        <?= $pageSelector->selectPage('productPublishTarget', $productPublishTarget); ?>
                     </div>
 
+                    <h3><?= t("Product Images"); ?></h3>
+                    <h4><?= t("Single Product - Legacy Thumbnail Generator"); ?></h4>
+                    <div class="row">
+                        <div class="form-group col-md-6">
+                            <?= $form->label('defaultSingleProductImageWidth', t('Single Product Image Width'), ['class' => 'sr-only']); ?>
+                            <div class="input-group">
+                                <div class="input-group-addon"><?php echo t("Width"); ?></div>
+                                <?= $form->number('defaultSingleProductImageWidth', Config::get('community_store.defaultSingleProductImageWidth') ?: 720, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-6">
+                            <?= $form->label('defaultSingleProductImageHeight', t('Single Product Image Height'), ['class' => 'sr-only']); ?>
+                            <div class="input-group">
+                                <div class="input-group-addon"><?php echo t("Height"); ?></div>
+                                <?= $form->number('defaultSingleProductImageHeight', Config::get('community_store.defaultSingleProductImageHeight') ?: 720, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <h4><?= t("Product List - Legacy Thumbnail Generator"); ?></h4>
+                    <div class="row">
+                        <div class="form-group col-md-6">
+                            <?= $form->label('defaultProductListImageWidth', t('Product List Image Width'), ['class' => 'sr-only']); ?>
+                            <div class="input-group">
+                                <div class="input-group-addon"><?php echo t("Width"); ?></div>
+                                <?= $form->number('defaultProductListImageWidth', Config::get('community_store.defaultProductListImageWidth') ?: 400, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-6">
+                            <?= $form->label('defaultProductListImageHeight', t('Product List Image Height'), ['class' => 'sr-only']); ?>
+                            <div class="input-group">
+                                <div class="input-group-addon"><?php echo t("Height"); ?></div>
+                                <?= $form->number('defaultProductListImageHeight', Config::get('community_store.defaultProductListImageHeight') ?: 280, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- #settings-customers -->
                 <div class="col-sm-9 store-pane" id="settings-checkout">
-                    <h3><?= t('Cart and Checkout');?></h3>
+                    <h3><?= t('Cart and Checkout'); ?></h3>
                     <div class="form-group">
-                        <?php $shoppingDisabled =  Config::get('community_store.shoppingDisabled');
+                        <?php $shoppingDisabled = Config::get('community_store.shoppingDisabled');
                         ?>
-                        <label><?= $form->radio('shoppingDisabled',' ', ($shoppingDisabled == '') ); ?> <?php  echo t('Enabled'); ?></label><br />
-                        <label><?= $form->radio('shoppingDisabled','all',$shoppingDisabled == 'all'); ?> <?php  echo t('Disabled (Catalog Mode)'); ?></label><br />
+                        <label><?= $form->radio('shoppingDisabled', ' ', ('' == $shoppingDisabled)); ?> <?php  echo t('Enabled'); ?></label><br />
+                        <label><?= $form->radio('shoppingDisabled', 'all', 'all' == $shoppingDisabled); ?> <?php  echo t('Disabled (Catalog Mode)'); ?></label><br />
                     </div>
 
-                    <h3><?= t('Guest Checkout');?></h3>
+                    <h3><?= t('Guest Checkout'); ?></h3>
                     <div class="form-group">
-                        <?php $guestCheckout =  Config::get('community_store.guestCheckout');
+                        <?php $guestCheckout = Config::get('community_store.guestCheckout');
                         $guestCheckout = ($guestCheckout ? $guestCheckout : 'off');
                         ?>
-                        <label><?= $form->radio('guestCheckout','always', $guestCheckout == 'always'); ?> <?php  echo t('Always (unless login required for products in cart)'); ?></label><br />
-                        <label><?= $form->radio('guestCheckout','option',$guestCheckout == 'option'); ?> <?php  echo t('Offer as checkout option'); ?></label><br />
-                        <label><?= $form->radio('guestCheckout','off', $guestCheckout == 'off' || $guestCheckout == '' ); ?> <?php  echo t('Disabled'); ?></label><br />
+                        <label><?= $form->radio('guestCheckout', 'always', 'always' == $guestCheckout); ?> <?php  echo t('Always (unless login required for products in cart)'); ?></label><br />
+                        <label><?= $form->radio('guestCheckout', 'option', 'option' == $guestCheckout); ?> <?php  echo t('Offer as checkout option'); ?></label><br />
+                        <label><?= $form->radio('guestCheckout', 'off', 'off' == $guestCheckout || '' == $guestCheckout); ?> <?php  echo t('Disabled'); ?></label><br />
                     </div>
 
-                    <h3><?= t('Address Auto-Complete');?></h3>
+                    <h3><?= t('Address Auto-Complete'); ?></h3>
                     <div class="form-group">
-                        <?= $form->label('placesAPIKey',t('Address Auto-Complete API Key (Google Places)')); ?>
-                        <?= $form->text('placesAPIKey',Config::get('community_store.placesAPIKey'));?>
+                        <?= $form->label('placesAPIKey', t('Address Auto-Complete API Key (Google Places)')); ?>
+                        <?= $form->text('placesAPIKey', Config::get('community_store.placesAPIKey')); ?>
                     </div>
 
-                    <h3><?= t('Company Name');?></h3>
+                    <h3><?= t('Company Name'); ?></h3>
                     <div class="form-group">
-                        <?php $companyField =  Config::get('community_store.companyField');
+                        <?php $companyField = Config::get('community_store.companyField');
                         $companyField = ($companyField ? $companyField : 'off');
                         ?>
-                        <label><?= $form->radio('companyField','off', $companyField == 'off' || $companyField == '' ); ?> <?php  echo t('Hidden'); ?></label><br />
-                        <label><?= $form->radio('companyField','optional',$companyField == 'optional'); ?> <?php  echo t('Optional'); ?></label><br />
-                        <label><?= $form->radio('companyField','required',$companyField == 'required'); ?> <?php  echo t('Required'); ?></label><br />
+                        <label><?= $form->radio('companyField', 'off', 'off' == $companyField || '' == $companyField); ?> <?php  echo t('Hidden'); ?></label><br />
+                        <label><?= $form->radio('companyField', 'optional', 'optional' == $companyField); ?> <?php  echo t('Optional'); ?></label><br />
+                        <label><?= $form->radio('companyField', 'required', 'required' == $companyField); ?> <?php  echo t('Required'); ?></label><br />
                     </div>
 
-                    <h3><?= t('Billing Details');?></h3>
+                    <h3><?= t('Billing Details'); ?></h3>
 
                     <div class="row">
                         <div class="col-xs-12">
-                            <label><?= $form->checkbox('noBillingSave', '1',Config::get('community_store.noBillingSave') ? '1' : '0')?>
-                                <?= t('Do not save billing details to user on order');?></label>
+                            <label><?= $form->checkbox('noBillingSave', '1', Config::get('community_store.noBillingSave') ? '1' : '0'); ?>
+                                <?= t('Do not save billing details to user on order'); ?></label>
                         </div>
                     </div>
 
                     <div class="row">
                         <div class="col-xs-12">
                             <div class="ccm-search-field-content ccm-search-field-content-select2">
-                                <?= t('For users in groups');?> <?php print $form->selectMultiple('noBillingSaveGroups', $groupList, explode(',', Config::get('community_store.noBillingSaveGroups')), array('class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('All Users/Groups'))); ?>
+                                <?= t('For users in groups'); ?> <?php echo $form->selectMultiple('noBillingSaveGroups', $groupList, explode(',', Config::get('community_store.noBillingSaveGroups')), ['class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('All Users/Groups')]); ?>
                             </div>
                         </div>
                     </div>
 
 
-                    <h3><?= t('Shipping Details');?></h3>
+                    <h3><?= t('Shipping Details'); ?></h3>
                     <div class="row">
                         <div class="col-xs-12">
-                            <label><?= $form->checkbox('noShippingSave', '1',Config::get('community_store.noShippingSave') ? '1' : '0')?>
-                                <?= t('Do not save shipping details to user on order');?></label>
+                            <label><?= $form->checkbox('noShippingSave', '1', Config::get('community_store.noShippingSave') ? '1' : '0'); ?>
+                                <?= t('Do not save shipping details to user on order'); ?></label>
                         </div>
                     </div>
 
                     <div class="row">
                         <div class="col-xs-12">
                             <div class="ccm-search-field-content ccm-search-field-content-select2">
-                                <?= t('For users in groups');?> <?php print $form->selectMultiple('noShippingSaveGroups', $groupList, explode(',', Config::get('community_store.noShippingSaveGroups')), array('class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('All Users/Groups'))); ?>
+                                <?= t('For users in groups'); ?> <?php echo $form->selectMultiple('noShippingSaveGroups', $groupList, explode(',', Config::get('community_store.noShippingSaveGroups')), ['class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('All Users/Groups')]); ?>
                             </div>
                         </div>
                     </div>
@@ -357,11 +401,11 @@
                         });
                     </script>
 
-                    <h3><?= t('Digital Download Expiry');?></h3>
+                    <h3><?= t('Digital Download Expiry'); ?></h3>
                     <div class="form-group">
-                        <?= $form->label('download_expiry_hours',t('Number of hours before digital download links expiry')); ?>
+                        <?= $form->label('download_expiry_hours', t('Number of hours before digital download links expiry')); ?>
                         <div class="input-group">
-                        <?= $form->number('download_expiry_hours',Config::get('community_store.download_expiry_hours'), array('placeholder'=>'48'));?>
+                        <?= $form->number('download_expiry_hours', Config::get('community_store.download_expiry_hours'), ['placeholder' => '48']); ?>
                         <div class="input-group-addon"><?= t('hours'); ?></div>
                         </div>
                     </div>
@@ -371,10 +415,10 @@
 
                 <!-- #settings-orders -->
                 <div class="col-sm-9 store-pane" id="settings-orders">
-                    <h3><?= t('Orders');?></h3>
+                    <h3><?= t('Orders'); ?></h3>
                     <div class="form-group">
-                        <label><?= $form->checkbox('showUnpaidExternalPaymentOrders', '1',Config::get('community_store.showUnpaidExternalPaymentOrders') ? '1' : '0')?>
-                            <?= t('Unhide orders with incomplete payments (i.e. cancelled Paypal transactions)');?></label></div>
+                        <label><?= $form->checkbox('showUnpaidExternalPaymentOrders', '1', Config::get('community_store.showUnpaidExternalPaymentOrders') ? '1' : '0'); ?>
+                            <?= t('Unhide orders with incomplete payments (i.e. cancelled Paypal transactions)'); ?></label></div>
 
                 </div>
 
@@ -382,7 +426,7 @@
 
     	    <div class="ccm-dashboard-form-actions-wrapper">
     	        <div class="ccm-dashboard-form-actions">
-    	            <button class="pull-right btn btn-success" type="submit" ><?= t('Save Settings')?></button>
+    	            <button class="pull-right btn btn-success" type="submit" ><?= t('Save Settings'); ?></button>
     	        </div>
     	    </div>
 

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -285,14 +285,19 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
                     <div class="row">
                         <h4 class="col-md-12"><?= t("Product Thumbnail Types"); ?></h4>
-                        <div class="form-group col-md-6">
+                        <div class="form-group col-md-4">
                             <?= $form->label('defaultSingleProductThumbType', t('Single Product Thumbnail Type')); ?>
                             <?= $form->select('defaultSingleProductThumbType', $thumbnailTypes, Config::get('community_store.defaultSingleProductThumbType')); ?>
                         </div>
 
-                        <div class="form-group col-md-6">
+                        <div class="form-group col-md-4">
                             <?= $form->label('defaultProductListThumbType', t('Product List Thumbnail Type')); ?>
                             <?= $form->select('defaultProductListThumbType', $thumbnailTypes, Config::get('community_store.defaultProductListThumbType')); ?>
+                        </div>
+
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultProductModalThumbType', t('Product Modal Thumbnail Type')); ?>
+                            <?= $form->select('defaultProductModalThumbType', $thumbnailTypes, Config::get('community_store.defaultProductModalThumbType')); ?>
                         </div>
                     </div>
 
@@ -353,6 +358,36 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                         <div class="form-group col-md-4">
                             <?= $form->label('defaultProductListCrop', t('Image cropping')); ?>
                             <?= $form->select('defaultProductListCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultProductListCrop')); ?>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <h4 class="col-md-12"><?= t("Product Modal - Legacy Thumbnail Generator"); ?></h4>
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultProductModalImageWidth', t('Image Width')); ?>
+                            <div class="input-group">
+                                <?= $form->number('defaultProductModalImageWidth', Config::get('community_store.defaultProductModalImageWidth') ?: Image::DEFAULT_PRODUCT_MODAL_IMG_WIDTH, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                            <div class="help-block">
+                                <?= t("Default value: %s", Image::DEFAULT_PRODUCT_MODAL_IMG_WIDTH); ?>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultProductModalImageHeight', t('Image Height')); ?>
+                            <div class="input-group">
+                                <?= $form->number('defaultProductModalImageHeight', Config::get('community_store.defaultProductModalImageHeight') ?: Image::DEFAULT_PRODUCT_MODAL_IMG_HEIGHT, ['min' => '0', 'step' => '1']); ?>
+                                <div class="input-group-addon">px</div>
+                            </div>
+                            <div class="help-block">
+                                <?= t("Default value: %s", Image::DEFAULT_PRODUCT_MODAL_IMG_HEIGHT); ?>
+                            </div>
+                        </div>
+
+                        <div class="form-group col-md-4">
+                            <?= $form->label('defaultProductModalCrop', t('Image cropping')); ?>
+                            <?= $form->select('defaultProductModalCrop', ['0' => t("Scale proportionally"), '1' => t("Scale and crop")], Config::get('community_store.defaultProductModalCrop')); ?>
                         </div>
                     </div>
                 </div>

--- a/src/CommunityStore/Utilities/Image.php
+++ b/src/CommunityStore/Utilities/Image.php
@@ -1,0 +1,204 @@
+<?php
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Utilities;
+
+use Config;
+use stdClass;
+use Concrete\Core\Entity\File\File;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\File\Image\Thumbnail\Type\Type as ThumbType;
+
+/**
+ * Image helper to get image information using thumbnail types with fallback on the legacy thumbnailer
+ * is instantiated with default general settings if none provided.
+ *
+ * [object Object]
+ */
+class Image
+{
+    const IMG_FOR_PRODUCT_LIST = 'product_list';
+    const IMG_FOR_SINGLE_PRODUCT = 'single_product';
+    const DEFAULT_SINGLE_PRODUCT_IMG_WIDTH = 720;
+    const DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT = 720;
+    const DEFAULT_PRODUCT_LIST_IMG_WIDTH = 400;
+    const DEFAULT_PRODUCT_LIST_IMG_HEIGHT = 280;
+    const DEFAULT_SINGLE_PRODUCT_IMG_CROP = false;
+
+    /** @var Application $app */
+    protected $app;
+    /** @var File $imgObj */
+    protected $imgObj;
+    /** @var stdClass $legacyThumbProps with properties width, height and crop */
+    protected $legacyThumbProps;
+    /** @var ThumbType $thumbType core thumbnail type */
+    protected $thumbType = null;
+    /** @var string $resizingScheme CamelCase version of either static::IMG_FOR_PRODUCT_LIST or static::IMG_FOR_SINGLE_PRODUCT */
+    protected $resizingScheme;
+
+    /**
+     * @param string $resizingScheme
+     * @param string $thumbTypeHandle
+     * @param stdClass $legacyThumbProps {width: integer|null, height: integer|null, crop: boolean|null}
+     */
+    public function __construct($resizingScheme = 'product_list', $thumbTypeHandle = null, $legacyThumbProps = null)
+    {
+        $this->app = Application::getFacadeApplication();
+        $this->legacyThumbProps = new stdClass();
+        $this->setResizingScheme($resizingScheme);
+        $this->setThumbType($thumbTypeHandle);
+        $this->setLegacyThumbnailingValues($legacyThumbProps);
+    }
+
+    /**
+     * Sets whether we are using the single product or product list image thumbnailing settings.
+     *
+     * @param string $resizingScheme one of IMG_FOR_PRODUCT_LIST or IMG_FOR_SINGLE_PRODUCT. Defaults to IMG_FOR_PRODUCT_LIST
+     */
+    public function setResizingScheme($resizingScheme)
+    {
+        // making sure we got a correct value
+        switch ($resizingScheme) {
+            case static::IMG_FOR_PRODUCT_LIST:
+            case static::IMG_FOR_SINGLE_PRODUCT:
+                $this->resizingScheme = camelcase($resizingScheme);
+                break;
+            default:
+                $this->resizingScheme = camelcase(static::IMG_FOR_PRODUCT_LIST);
+                break;
+        }
+    }
+
+    /**
+     * Sets the Thumbnail Type to use. Defaults to the one selected in general settings if any.
+     *
+     * @param string $thumbTypeHandle
+     */
+    public function setThumbType($thumbTypeHandle)
+    {
+        // A thumb type handle was provided, let's use that
+        if (!empty($thumbTypeHandle)) {
+            $this->thumbType = ThumbType::getByHandle($thumbTypeHandle);
+        }
+
+        // No thumb type handle was provided or it didn't return a proper thumb type pbject
+        // let's use the one from general settings if any
+        if (empty($thumbTypeHandle) || !is_object($this->thumbType)) {
+            $thumbTypeID = Config::get('community_store.default' . $this->resizingScheme . 'ThumbType');
+            if (!empty($thumbTypeID)) {
+                $this->thumbType = ThumbType::getByID($thumbTypeID);
+            }
+        }
+    }
+
+    /**
+     * Sets the legacy thumbnailer's width, height, and crop values.
+     *
+     * @param stdClass $legacyThumbProps {width: integer|null, height: integer|null, crop: boolean|null}
+     */
+    protected function setLegacyThumbnailingValues($legacyThumbProps)
+    {
+        $legacyThumbProps = is_object($legacyThumbProps) ? $legacyThumbProps : new stdClass();
+
+        $this->setLegacyThumbnailWidth($legacyThumbProps->width);
+        $this->setLegacyThumbnailHeight($legacyThumbProps->height);
+        $this->setLegacyThumbnailCrop($legacyThumbProps->crop);
+    }
+
+    /**
+     * Sets the legacy thumbnailer's width.
+     *
+     * @param int|string $width
+     */
+    public function setLegacyThumbnailWidth($width)
+    {
+        $this->legacyThumbProps = is_object($this->legacyThumbProps) ? $this->legacyThumbProps : new stdClass();
+
+        $this->legacyThumbProps->width = (isset($width) && !empty($width)) ? (int) $width : (int) Config::get('community_store.default' . $this->resizingScheme . 'ImageWidth');
+
+        if (!$this->legacyThumbProps->width) {
+            $const = 'DEFAULT_' . strtoupper(uncamelcase($this->resizingScheme)) . '_IMG_WIDTH';
+            $this->legacyThumbProps->width = constant('static::{$const}');
+        }
+    }
+
+    /**
+     * Sets the legacy thumbnailer's height.
+     *
+     * @param int|string $height
+     */
+    public function setLegacyThumbnailHeight($height)
+    {
+        $this->legacyThumbProps = is_object($this->legacyThumbProps) ? $this->legacyThumbProps : new stdClass();
+
+        $this->legacyThumbProps->height = (isset($height) && !empty($height)) ? (int) $height : (int) Config::get('community_store.default' . $this->resizingScheme . 'ImageHeight');
+
+        if (!$this->legacyThumbProps->height) {
+            $const = 'DEFAULT_' . strtoupper(uncamelcase($this->resizingScheme)) . '_IMG_HEIGHT';
+            $this->legacyThumbProps->height = constant('static::{$const}');
+        }
+    }
+
+    /**
+     * Sets the legacy thumbnailer's crop.
+     *
+     * @param bool $crop
+     */
+    public function setLegacyThumbnailCrop($crop)
+    {
+        $this->legacyThumbProps = is_object($this->legacyThumbProps) ? $this->legacyThumbProps : new stdClass();
+
+        $this->legacyThumbProps->crop = isset($crop) ? (bool) $crop : static::DEFAULT_SINGLE_PRODUCT_IMG_CROP;
+    }
+
+    /**
+     * Gets a thumbnail src and optionally a retinaSrc to display on a page.
+     *
+     * @param File $imgObj
+     *
+     * @return returns stdClass with property src and optionally retinaSrc
+     * [object Object]
+     */
+    public function getThumbnail(File $imgObj)
+    {
+        return $this->getThumbTypeThumbnail($imgObj);
+    }
+
+    /**
+     * Gets a thumbnail src and optionally a retinaSrc based on thumbnail type with fallback on legacy thumbnailer.
+     *
+     * @param File  stdClass with property src and optionally retinaSrc
+     */
+    public function getThumbTypeThumbnail(File $imgObj)
+    {
+        $thumb = new StdClass();
+        $this->imgObj = $imgObj;
+
+        if (is_object($this->thumbType)) {
+            $baseVersion = $this->thumbType->getBaseVersion();
+            $thumb->src = $imgObj->getThumbnailURL($baseVersion);
+
+            if ($thumb->src) {
+                $retinaVersion = $this->thumbType->getDoubledVersion();
+                $thumb->retinaSrc = $imgObj->getThumbnailURL($retinaVersion);
+
+                return $thumb;
+            }
+        }
+
+        return $this->getLegacyThumbnail($imgObj);
+    }
+
+    /**
+     * Gets a thumbnail src from the legacy thumbnailer.
+     *
+     * @param File  stdClass with property src
+     */
+    public function getLegacyThumbnail(File $imgObj)
+    {
+        $image = new StdClass();
+        $this->imgObj = $imgObj;
+
+        $thumb = $this->app->make('helper/image')->getThumbnail($imgObj, $this->legacyThumbProps->width, $this->legacyThumbProps->height, $this->legacyThumbProps->crop);
+
+        return $thumb;
+    }
+}

--- a/src/CommunityStore/Utilities/Image.php
+++ b/src/CommunityStore/Utilities/Image.php
@@ -120,7 +120,7 @@ class Image
 
         if (!$this->legacyThumbProps->width) {
             $const = 'DEFAULT_' . strtoupper(uncamelcase($this->resizingScheme)) . '_IMG_WIDTH';
-            $this->legacyThumbProps->width = constant('static::{$const}');
+            $this->legacyThumbProps->width = constant('self::' . $const);
         }
     }
 
@@ -137,7 +137,7 @@ class Image
 
         if (!$this->legacyThumbProps->height) {
             $const = 'DEFAULT_' . strtoupper(uncamelcase($this->resizingScheme)) . '_IMG_HEIGHT';
-            $this->legacyThumbProps->height = constant('static::{$const}');
+            $this->legacyThumbProps->height = constant('self::' . $const);
         }
     }
 

--- a/src/CommunityStore/Utilities/Image.php
+++ b/src/CommunityStore/Utilities/Image.php
@@ -17,11 +17,14 @@ class Image
 {
     const IMG_FOR_PRODUCT_LIST = 'product_list';
     const IMG_FOR_SINGLE_PRODUCT = 'single_product';
+    const IMG_FOR_PRODUCT_MODAL = 'product_modal';
     const DEFAULT_SINGLE_PRODUCT_IMG_WIDTH = 720;
     const DEFAULT_SINGLE_PRODUCT_IMG_HEIGHT = 720;
     const DEFAULT_PRODUCT_LIST_IMG_WIDTH = 400;
     const DEFAULT_PRODUCT_LIST_IMG_HEIGHT = 280;
-    const DEFAULT_SINGLE_PRODUCT_IMG_CROP = false;
+    const DEFAULT_PRODUCT_MODAL_IMG_WIDTH = 560;
+    const DEFAULT_PRODUCT_MODAL_IMG_HEIGHT = 999;
+    const DEFAULT_IMG_CROP = false;
 
     /** @var Application $app */
     protected $app;
@@ -31,7 +34,7 @@ class Image
     protected $legacyThumbProps;
     /** @var ThumbType $thumbType core thumbnail type */
     protected $thumbType = null;
-    /** @var string $resizingScheme CamelCase version of either static::IMG_FOR_PRODUCT_LIST or static::IMG_FOR_SINGLE_PRODUCT */
+    /** @var string $resizingScheme CamelCase version of either static::IMG_FOR_PRODUCT_LIST, static::IMG_FOR_SINGLE_PRODUCT or static::IMG_FOR_PRODUCT_MODAL */
     protected $resizingScheme;
 
     /**
@@ -51,7 +54,7 @@ class Image
     /**
      * Sets whether we are using the single product or product list image thumbnailing settings.
      *
-     * @param string $resizingScheme one of IMG_FOR_PRODUCT_LIST or IMG_FOR_SINGLE_PRODUCT. Defaults to IMG_FOR_PRODUCT_LIST
+     * @param string $resizingScheme one of IMG_FOR_PRODUCT_LIST, IMG_FOR_SINGLE_PRODUCT or IMG_FOR_PRODUCT_MODAL. Defaults to IMG_FOR_PRODUCT_LIST
      */
     public function setResizingScheme($resizingScheme)
     {
@@ -59,6 +62,7 @@ class Image
         switch ($resizingScheme) {
             case static::IMG_FOR_PRODUCT_LIST:
             case static::IMG_FOR_SINGLE_PRODUCT:
+            case static::IMG_FOR_PRODUCT_MODAL:
                 $this->resizingScheme = camelcase($resizingScheme);
                 break;
             default:
@@ -146,7 +150,7 @@ class Image
     {
         $this->legacyThumbProps = is_object($this->legacyThumbProps) ? $this->legacyThumbProps : new stdClass();
 
-        $this->legacyThumbProps->crop = isset($crop) ? (bool) $crop : static::DEFAULT_SINGLE_PRODUCT_IMG_CROP;
+        $this->legacyThumbProps->crop = isset($crop) ? (bool) $crop : static::DEFAULT_IMG_CROP;
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for thumbnail types in Community Store.

It affects:

- the Product list block images
- the single product block images
- the modal images

For all 3 types, settings can be found on the settings page under the product tab

Each can be given

- a thumbnail type
- width, height, and a crop value for the legacy thumbnail generator

I introduced a custom image helper that will deal with thumbnail types and fallback to the legacy thumbnail generator if needed.

The fallback will be used if

- no thumbnail type was selected
- a thumbnail type was selected but it not available anymore
- the image doesn't have a thumbnail for the selected type yet

The image helper is loaded from the package's on_start() function as a singleton with the label 'cs/helper/image' to make it look familiar to users of C5 image helper.

It can be instantiated easily with just one argument, either 'single_product', 'product_list' or 'product_modal' in which case it will load all the saved values from settings or default values if needed.

It can also be instantiated with custom values for the thumbnail type and legacy thumbnail generator to be able to easily use any other than those saved in the settings.

Once instantiated, values can also be changed on the fly. For instance, I do that to change the crop value from false to true using the same object in the product block.

Blocks will keep working when updating even when using block templates.

Users with no block templates will be able to benefit from thumbnail types right away by just selecting them from the dashboard settings page.

Users with block templates will have to modify their templates to use thumbnail types which is easy enough to do. I will write a quick help page later in the Wiki if you decide to merge this in the core