### PR TITLE
Make Customer Group and Digital download fileset accessible through settings

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -18,7 +18,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '8.2.1';
-    protected $pkgVersion = '2.1.1';
+    protected $pkgVersion = '2.1.1.1';
 
     protected $pkgAutoloaderRegistries = [
         'src/CommunityStore' => '\Concrete\Package\CommunityStore\Src\CommunityStore',
@@ -114,7 +114,7 @@ class Controller extends Package
     {
         $singletons = [
             'cs/helper/image' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image',
-            'cs/helper/multilingual' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Multilingual'
+            'cs/helper/multilingual' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Multilingual',
         ];
 
         foreach ($singletons as $key => $value) {
@@ -195,8 +195,8 @@ class Controller extends Package
         $c = Page::getCurrentPage();
         $al = Section::getBySectionOfSite($c);
         $langpath = '';
-        if ($al !== null) {
-            $langpath =  $al->getCollectionHandle();
+        if (null !== $al) {
+            $langpath = $al->getCollectionHandle();
         }
 
         return "
@@ -227,5 +227,3 @@ class Controller extends Package
         );
     }
 }
-
-

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -4,7 +4,10 @@ namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Package\Package;
 use Concrete\Core\Routing\Redirect;
+use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\Group\GroupList;
+use Concrete\Core\File\Set\SetList;
+use Concrete\Core\File\Set\Set as FileSet;
 use Concrete\Core\Support\Facade\Config;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\File\Image\Thumbnail\Type\Type as ThumbType;
@@ -24,15 +27,6 @@ class Settings extends DashboardPageController
         $this->set("states", $this->app->make('helper/lists/states_provinces')->getStates());
         $this->set("installedPaymentMethods", StorePaymentMethod::getMethods());
         $this->set("orderStatuses", StoreOrderStatus::getAll());
-        $targetCID = Config::get('community_store.productPublishTarget');
-
-        if ($targetCID > 0) {
-            $parentPage = Page::getByID($targetCID);
-
-            if (!$parentPage || $parentPage->isError()) {
-                $targetCID = false;
-            }
-        }
 
         $groupList = [];
 
@@ -43,6 +37,8 @@ class Settings extends DashboardPageController
 
         $this->set('groupList', $groupList);
 
+        $targetCID = Config::get('community_store.productPublishTarget');
+
         if ($targetCID) {
             $publishTarget = Page::getByID($targetCID);
 
@@ -52,6 +48,44 @@ class Settings extends DashboardPageController
         }
 
         $this->set('productPublishTarget', $targetCID);
+
+        $customerGroupID = Config::get('community_store.customerGroup');
+        $customerGroupName = null;
+
+        if ($customerGroupID) {
+            $customerGroup = Group::getByID($customerGroupID);
+
+            if (!$customerGroup || !is_object($customerGroup)) {
+                $customerGroupID = null;
+            } else {
+                $customerGroupName = $customerGroup->getGroupName();
+            }
+        }
+
+        $this->set('customerGroup', $customerGroupID);
+        $this->set('customerGroupName', $customerGroupName);
+
+        $fsl = new SetList();
+        $fileSets = $fsl->get();
+        $sets = [];
+        if (count($fileSets)) {
+            foreach ($fileSets  as  $fileSet) {
+                $sets[$fileSet->getFileSetID()] = $fileSet->getFileSetName();
+            }
+        }
+        $this->set('fileSets', $sets);
+
+        $fsID = Config::get('community_store.digitalDownloadFileSet');
+
+        if ($fsID) {
+            $fs = FileSet::getByID($fsID);
+
+            if (!$fs || !is_object($fs)) {
+                $fsID = null;
+            }
+        }
+
+        $this->set('digitalDownloadFileSet', $fsID);
     }
 
     public function loadFormAssets()
@@ -121,6 +155,8 @@ class Settings extends DashboardPageController
                 Config::save('community_store.notificationemails', $args['notificationEmails']);
                 Config::save('community_store.emailalerts', $args['emailAlert']);
                 Config::save('community_store.emailalertsname', $args['emailAlertName']);
+                Config::save('community_store.customerGroup', $args['customerGroup']);
+                Config::save('community_store.digitalDownloadFileSet', $args['digitalDownloadFileSet']);
                 Config::save('community_store.productPublishTarget', $args['productPublishTarget']);
                 Config::save('community_store.defaultSingleProductThumbType', $args['defaultSingleProductThumbType']);
                 Config::save('community_store.defaultProductListThumbType', $args['defaultProductListThumbType']);

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -290,6 +290,9 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                         <?= $form->label('customerGroup', t('Customer Group to Put Customers in')); ?>
                         <?= $form->select('customerGroup', $groupList, $customerGroup, ['class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('Select a Group')]); ?>
                     </div>
+                    <div class="alert alert-warning">
+                        <?= t("If you change group remember to switch your existing customers over to the new group"); ?>
+                    </div>
                 </div>
             </div>
         </div>
@@ -426,6 +429,9 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
             <div class="form-group">
                 <?= $form->label('digitalDownloadFileSet', t('Digital Downloads FileSet')); ?>
                 <?= $form->select('digitalDownloadFileSet', $fileSets, $digitalDownloadFileSet); ?>
+                <div class="alert alert-warning">
+                    <?= t("If you change fileset remember to switch your existing digital downloads over to the new fileset"); ?>
+                </div>
             </div>
         </div>
 

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -25,8 +25,10 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                 <li><a href="#settings-payments" data-pane-toggle><?= t('Payments'); ?></a></li>
                 <li><a href="#settings-order-statuses" data-pane-toggle><?= t('Fulfilment Statuses'); ?></a></li>
                 <li><a href="#settings-notifications" data-pane-toggle><?= t('Notifications and Receipts'); ?></a></li>
+                <li><a href="#settings-customers" data-pane-toggle><?= t('Customers'); ?></a></li>
                 <li><a href="#settings-products" data-pane-toggle><?= t('Products'); ?></a></li>
                 <li><a href="#settings-product-images" data-pane-toggle><?= t('Product Images'); ?></a></li>
+                <li><a href="#settings-digital-downloads" data-pane-toggle><?= t('Digital Downloads'); ?></a></li>
                 <li><a href="#settings-checkout" data-pane-toggle><?= t('Cart and Checkout'); ?></a></li>
                 <li><a href="#settings-orders" data-pane-toggle><?= t('Orders'); ?></a></li>
             </ul>
@@ -83,14 +85,14 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                 <div class="col-xs-6">
                     <div class="form-group">
                         <?= $form->label('weightUnit', t('Units for Weight')); ?>
-                        <?php // do not add other units to this list. these are specific to making calculated shipping work?>
+                        <?php  ?>
                         <?= $form->select('weightUnit', ['oz' => t('oz'), 'lb' => t('lb'), 'kg' => t('kg'), 'g' => t('g')], Config::get('community_store.weightUnit')); ?>
                     </div>
                 </div>
                 <div class="col-xs-6">
                     <div class="form-group">
                         <?= $form->label('sizeUnit', t('Units for Size')); ?>
-                        <?php // do not add other units to this list. these are specific to making calculated shipping work?>
+                        <?php  ?>
                         <?= $form->select('sizeUnit', ['in' => t('in'), 'cm' => t('cm'), 'mm' => t('mm')], Config::get('community_store.sizeUnit')); ?>
                     </div>
                 </div>
@@ -122,49 +124,50 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                 foreach ($installedPaymentMethods as $pm) {
                     ?>
 
-                    <div class="panel panel-default">
+            <div class="panel panel-default">
 
-                        <div class="panel-heading"><?= t($pm->getName()); ?></div>
-                        <div class="panel-body">
-                            <div class="form-group paymentMethodEnabled">
-                                <input type="hidden" name="paymentMethodHandle[<?= $pm->getID(); ?>]" value="<?= $pm->getHandle(); ?>">
-                                <label><?= t("Enabled"); ?></label>
-                                <?php
-                                echo $form->select("paymentMethodEnabled[" . $pm->getID() . "]", [0 => t("No"), 1 => t("Yes")], $pm->isEnabled()); ?>
+                <div class="panel-heading"><?= t($pm->getName()); ?></div>
+                <div class="panel-body">
+                    <div class="form-group paymentMethodEnabled">
+                        <input type="hidden" name="paymentMethodHandle[<?= $pm->getID(); ?>]" value="<?= $pm->getHandle(); ?>">
+                        <label><?= t("Enabled"); ?></label>
+                        <?php
+                        echo $form->select("paymentMethodEnabled[" . $pm->getID() . "]", [0 => t("No"), 1 => t("Yes")], $pm->isEnabled()); ?>
+                    </div>
+                    <div id="paymentMethodForm-<?= $pm->getID(); ?>" style="display:<?= $pm->isEnabled() ? 'block' : 'none'; ?>">
+                        <div class="row">
+                            <div class="form-group col-sm-6">
+                                <label><?= t("Display Name (on checkout)"); ?></label>
+                                <?= $form->text('paymentMethodDisplayName[' . $pm->getID() . ']', $pm->getDisplayName()); ?>
                             </div>
-                            <div id="paymentMethodForm-<?= $pm->getID(); ?>" style="display:<?= $pm->isEnabled() ? 'block' : 'none'; ?>">
-                                <div class="row">
-                                    <div class="form-group col-sm-6">
-                                        <label><?= t("Display Name (on checkout)"); ?></label>
-                                        <?= $form->text('paymentMethodDisplayName[' . $pm->getID() . ']', $pm->getDisplayName()); ?>
-                                    </div>
-                                    <div class="form-group col-sm-6">
-                                        <label><?= t("Button Label"); ?></label>
-                                        <?= $form->text('paymentMethodButtonLabel[' . $pm->getID() . ']', $pm->getButtonLabel(), ['placeholder' => t('Optional')]); ?>
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label><?= t("Sort Order"); ?></label>
-                                    <?= $form->text('paymentMethodSortOrder[' . $pm->getID() . ']', $pm->getSortOrder()); ?>
-                                </div>
-                                <?php
-                                $pm->renderDashboardForm(); ?>
+                            <div class="form-group col-sm-6">
+                                <label><?= t("Button Label"); ?></label>
+                                <?= $form->text('paymentMethodButtonLabel[' . $pm->getID() . ']', $pm->getButtonLabel(), ['placeholder' => t('Optional')]); ?>
                             </div>
-
                         </div>
-
+                        <div class="form-group">
+                            <label><?= t("Sort Order"); ?></label>
+                            <?= $form->text('paymentMethodSortOrder[' . $pm->getID() . ']', $pm->getSortOrder()); ?>
+                        </div>
+                        <?php
+                        $pm->renderDashboardForm(); ?>
                     </div>
 
-                    <?php
-                }
-            } else {
-                echo t("No Payment Methods are Installed");
-            }
-            ?>
+                </div>
+
+            </div>
+
+            <?php
+
+        }
+    } else {
+        echo t("No Payment Methods are Installed");
+    }
+    ?>
 
             <script>
-                $(function () {
-                    $('.paymentMethodEnabled SELECT').on('change', function () {
+                $(function() {
+                    $('.paymentMethodEnabled SELECT').on('change', function() {
                         var $this = $(this);
                         if ($this.val() == 1) {
                             $this.parent().next().slideDown();
@@ -181,10 +184,10 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
             <?php
             if (count($orderStatuses) > 0) {
                 ?>
-                <div class="panel panel-default">
+            <div class="panel panel-default">
 
-                    <table class="table" id="orderStatusTable">
-                        <thead>
+                <table class="table" id="orderStatusTable">
+                    <thead>
                         <tr>
                             <th rowspan="1">&nbsp;</th>
                             <th rowspan="1"><?= t('Display Name'); ?></th>
@@ -195,40 +198,41 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                             <th><?= t('Site'); ?></th>
                             <th><?= t('Customer'); ?></th>
                         </tr>
-                        </thead>
-                        <tbody>
+                    </thead>
+                    <tbody>
                         <?php foreach ($orderStatuses as $orderStatus) {
                             ?>
-                            <tr>
-                                <td class="sorthandle"><input type="hidden" name="osID[]" value="<?= $orderStatus->getID(); ?>"><i class="fa fa-arrows-v"></i></td>
-                                <td><input type="text" name="osName[]" value="<?= t($orderStatus->getName()); ?>" placeholder="<?= $orderStatus->getReadableHandle(); ?>" class="form-control ccm-input-text"></td>
-                                <td><input type="radio" name="osIsStartingStatus" value="<?= $orderStatus->getID(); ?>" <?= $orderStatus->isStartingStatus() ? 'checked' : ''; ?>></td>
-                                <td style="display:none;"><input type="checkbox" name="osInformSite[]" value="1" <?= $orderStatus->getInformSite() ? 'checked' : ''; ?> class="form-control"></td>
-                                <td style="display:none;"><input type="checkbox" name="osInformCustomer[]" value="1" <?= $orderStatus->getInformCustomer() ? 'checked' : ''; ?> class="form-control"></td>
-                            </tr>
-                            <?php
-                        } ?>
-                        </tbody>
-                    </table>
-                    <script>
-                        $(function () {
-                            $('#orderStatusTable TBODY').sortable({
-                                cursor: 'move',
-                                opacity: 0.5,
-                                handle: '.sorthandle'
-                            });
+                        <tr>
+                            <td class="sorthandle"><input type="hidden" name="osID[]" value="<?= $orderStatus->getID(); ?>"><i class="fa fa-arrows-v"></i></td>
+                            <td><input type="text" name="osName[]" value="<?= t($orderStatus->getName()); ?>" placeholder="<?= $orderStatus->getReadableHandle(); ?>" class="form-control ccm-input-text"></td>
+                            <td><input type="radio" name="osIsStartingStatus" value="<?= $orderStatus->getID(); ?>" <?= $orderStatus->isStartingStatus() ? 'checked' : ''; ?>></td>
+                            <td style="display:none;"><input type="checkbox" name="osInformSite[]" value="1" <?= $orderStatus->getInformSite() ? 'checked' : ''; ?> class="form-control"></td>
+                            <td style="display:none;"><input type="checkbox" name="osInformCustomer[]" value="1" <?= $orderStatus->getInformCustomer() ? 'checked' : ''; ?> class="form-control"></td>
+                        </tr>
+                        <?php
 
+                    } ?>
+                    </tbody>
+                </table>
+                <script>
+                    $(function() {
+                        $('#orderStatusTable TBODY').sortable({
+                            cursor: 'move',
+                            opacity: 0.5,
+                            handle: '.sorthandle'
                         });
 
-                    </script>
+                    });
+                </script>
 
-                </div>
+            </div>
 
-                <?php
-            } else {
-                echo t("No Fulfilment Statuses are available");
-            }
-            ?>
+            <?php
+
+        } else {
+            echo t("No Fulfilment Statuses are available");
+        }
+        ?>
 
 
         </div><!-- #settings-order-statuses -->
@@ -275,6 +279,19 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
             </div>
 
 
+        </div>
+
+        <!-- #settings-customers -->
+        <div class="col-sm-9 store-pane" id="settings-customers">
+            <h3><?= t("Customers"); ?></h3>
+            <div class="row">
+                <div class="col-xs-12">
+                    <div class="ccm-search-field-content ccm-search-field-content-select2">
+                        <?= $form->label('customerGroup', t('Customer Group to Put Customers in')); ?>
+                        <?= $form->select('customerGroup', $groupList, $customerGroup, ['class' => 'existing-select2', 'style' => 'width: 100%', 'placeholder' => t('Select a Group')]); ?>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- #settings-products -->
@@ -402,15 +419,24 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                 </div>
             </div>
         </div>
+        
+        <!-- #settings-digital-downloads -->
+        <div class="col-sm-9 store-pane" id="settings-digital-downloads">
+            <h3><?= t("Digital Downloads"); ?></h3>
+            <div class="form-group">
+                <?= $form->label('digitalDownloadFileSet', t('Digital Downloads FileSet')); ?>
+                <?= $form->select('digitalDownloadFileSet', $fileSets, $digitalDownloadFileSet); ?>
+            </div>
+        </div>
 
-        <!-- #settings-customers -->
+        <!-- #settings-checkout -->
         <div class="col-sm-9 store-pane" id="settings-checkout">
             <h3><?= t('Cart and Checkout'); ?></h3>
             <div class="form-group">
                 <?php $shoppingDisabled = Config::get('community_store.shoppingDisabled');
                 ?>
-                <label><?= $form->radio('shoppingDisabled', ' ', ('' == $shoppingDisabled)); ?><?php echo t('Enabled'); ?></label><br/>
-                <label><?= $form->radio('shoppingDisabled', 'all', 'all' == $shoppingDisabled); ?><?php echo t('Disabled (Catalog Mode)'); ?></label><br/>
+                <label><?= $form->radio('shoppingDisabled', ' ', ('' == $shoppingDisabled)); ?><?php echo t('Enabled'); ?></label><br />
+                <label><?= $form->radio('shoppingDisabled', 'all', 'all' == $shoppingDisabled); ?><?php echo t('Disabled (Catalog Mode)'); ?></label><br />
             </div>
 
             <h3><?= t('Guest Checkout'); ?></h3>
@@ -418,9 +444,9 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                 <?php $guestCheckout = Config::get('community_store.guestCheckout');
                 $guestCheckout = ($guestCheckout ? $guestCheckout : 'off');
                 ?>
-                <label><?= $form->radio('guestCheckout', 'always', 'always' == $guestCheckout); ?><?php echo t('Always (unless login required for products in cart)'); ?></label><br/>
-                <label><?= $form->radio('guestCheckout', 'option', 'option' == $guestCheckout); ?><?php echo t('Offer as checkout option'); ?></label><br/>
-                <label><?= $form->radio('guestCheckout', 'off', 'off' == $guestCheckout || '' == $guestCheckout); ?><?php echo t('Disabled'); ?></label><br/>
+                <label><?= $form->radio('guestCheckout', 'always', 'always' == $guestCheckout); ?><?php echo t('Always (unless login required for products in cart)'); ?></label><br />
+                <label><?= $form->radio('guestCheckout', 'option', 'option' == $guestCheckout); ?><?php echo t('Offer as checkout option'); ?></label><br />
+                <label><?= $form->radio('guestCheckout', 'off', 'off' == $guestCheckout || '' == $guestCheckout); ?><?php echo t('Disabled'); ?></label><br />
             </div>
 
             <h3><?= t('Address Auto-Complete'); ?></h3>
@@ -434,9 +460,9 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                 <?php $companyField = Config::get('community_store.companyField');
                 $companyField = ($companyField ? $companyField : 'off');
                 ?>
-                <label><?= $form->radio('companyField', 'off', 'off' == $companyField || '' == $companyField); ?><?php echo t('Hidden'); ?></label><br/>
-                <label><?= $form->radio('companyField', 'optional', 'optional' == $companyField); ?><?php echo t('Optional'); ?></label><br/>
-                <label><?= $form->radio('companyField', 'required', 'required' == $companyField); ?><?php echo t('Required'); ?></label><br/>
+                <label><?= $form->radio('companyField', 'off', 'off' == $companyField || '' == $companyField); ?><?php echo t('Hidden'); ?></label><br />
+                <label><?= $form->radio('companyField', 'optional', 'optional' == $companyField); ?><?php echo t('Optional'); ?></label><br />
+                <label><?= $form->radio('companyField', 'required', 'required' == $companyField); ?><?php echo t('Required'); ?></label><br />
             </div>
 
             <h3><?= t('Billing Details'); ?></h3>
@@ -475,7 +501,7 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
 
             <script>
-                $(document).ready(function () {
+                $(document).ready(function() {
                     $('.existing-select2').select2();
                     $('.select2-container').removeClass('form-control');
                 });

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -863,7 +863,7 @@ class Order
 
             //add user to Store Customers group
             $group = Group::getByID(Config::get('community_store.customerGroup', 0));
-            if (is_object($group) || $group->getGroupID() < 1) {
+            if (is_object($group) && $group->getGroupID() >= 1) {
                 $user->getUserObject()->enterGroup($group);
             }
 

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -37,7 +37,6 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderStatus\OrderSt
  */
 class Order
 {
-
     use ObjectTrait;
     /**
      * @ORM\Id @ORM\Column(type="integer")
@@ -233,7 +232,7 @@ class Order
 
     public function setShippingTotal($shippingTotal)
     {
-        $this->oShippingTotal = (float)$shippingTotal;
+        $this->oShippingTotal = (float) $shippingTotal;
     }
 
     public function setTaxTotal($taxTotal)
@@ -485,7 +484,6 @@ class Order
         return $this->getObjectAttributeCategory()->getAttributeValues($this);
     }
 
-
     /**
      * @ORM\param array $data
      * @ORM\param StorePaymentMethod $pm
@@ -512,7 +510,7 @@ class Order
         $discountRatio = $totals['discountRatio'];
 
         $pmName = $pm->getName();
-        $pmDisplayName = $csm->t($pm->getDisplayName() , 'paymentDisplayName', null, $pm->getID());
+        $pmDisplayName = $csm->t($pm->getDisplayName(), 'paymentDisplayName', null, $pm->getID());
 
         $taxCalc = Config::get('community_store.calculation');
 
@@ -528,7 +526,7 @@ class Order
                     $taxTotal[] = $tax['taxamount'];
                 }
 
-                $taxlabel = $csm->t($tax['name'] , 'taxRateName', null, $tax['id']);
+                $taxlabel = $csm->t($tax['name'], 'taxRateName', null, $tax['id']);
                 $taxLabels[] = $taxlabel;
             }
         }
@@ -797,7 +795,7 @@ class Order
                 try {
                     $mh->sendMail();
                 } catch (\Exception $e) {
-                    Log::addWarning(t('Community Store: a new user email failed sending to %s', array($email)));
+                    Log::addWarning(t('Community Store: a new user email failed sending to %s', [$email]));
                 }
             }
         }
@@ -864,7 +862,7 @@ class Order
             }
 
             //add user to Store Customers group
-            $group = Group::getByName('Store Customer');
+            $group = Group::getByID(Config::get('community_store.customerGroup', 0));
             if (is_object($group) || $group->getGroupID() < 1) {
                 $user->getUserObject()->enterGroup($group);
             }
@@ -887,11 +885,11 @@ class Order
         $notificationEmails = explode(",", Config::get('community_store.notificationemails'));
         $notificationEmails = array_map('trim', $notificationEmails);
 
-        foreach($this->getOrderItems() as $oi) {
+        foreach ($this->getOrderItems() as $oi) {
             $product = $oi->getProductObject();
 
             if ($product) {
-                $notificationEmails  = array_merge($notificationEmails, $product->getNotificationEmailsArray());
+                $notificationEmails = array_merge($notificationEmails, $product->getNotificationEmailsArray());
             }
         }
 
@@ -945,7 +943,7 @@ class Order
             try {
                 $mh->sendMail();
             } catch (\Exception $e) {
-                Log::addWarning(t('Community Store: a notification email failed sending to %s', array(implode(', ', $notificationEmails))));
+                Log::addWarning(t('Community Store: a notification email failed sending to %s', [implode(', ', $notificationEmails)]));
             }
         }
     }
@@ -999,7 +997,7 @@ class Order
         try {
             $mh->sendMail();
         } catch (\Exception $e) {
-            Log::addWarning(t('Community Store: a receipt email failed sending to %s', array($email)));
+            Log::addWarning(t('Community Store: a receipt email failed sending to %s', [$email]));
         }
     }
 
@@ -1045,7 +1043,6 @@ class Order
         $em->flush();
     }
 
-
     public function remove()
     {
         $em = dbORM::entityManager();
@@ -1060,7 +1057,7 @@ class Order
 
         $attributes = $this->getAttributes();
 
-        foreach($attributes as $attribute) {
+        foreach ($attributes as $attribute) {
             $em->remove($attribute);
         }
 
@@ -1116,6 +1113,7 @@ class Order
     public function getObjectAttributeCategory()
     {
         $app = Application::getFacadeApplication();
+
         return $app->make('\Concrete\Package\CommunityStore\Attribute\Category\OrderCategory');
     }
 
@@ -1138,6 +1136,7 @@ class Order
             $attributeValue = new StoreOrderValue();
             $attributeValue->setOrder($this);
             $attributeValue->setAttributeKey($ak);
+
             return $attributeValue;
         }
     }
@@ -1152,7 +1151,7 @@ class Order
         $displayName = $discount->getDisplay();
         $displayName = $csm->t($displayName, 'discountRuleDisplayName', null, $discount->getID());
 
-        $vals = [$this->oID, $discount->drName, $displayName , $discount->drValue, $discount->drPercentage, $discount->drDeductFrom, $code];
+        $vals = [$this->oID, $discount->drName, $displayName, $discount->drValue, $discount->drPercentage, $discount->drDeductFrom, $code];
         $db->query("INSERT INTO CommunityStoreOrderDiscounts(oID,odName,odDisplay,odValue,odPercentage,odDeductFrom,odCode) VALUES (?,?,?,?,?,?,?)", $vals);
     }
 

--- a/src/CommunityStore/Product/ProductFile.php
+++ b/src/CommunityStore/Product/ProductFile.php
@@ -95,12 +95,15 @@ class ProductFile
         self::removeFilesForProduct($product);
         //add new ones.
         if (!empty($files['ddfID'])) {
+            $fs = FileSet::getByID(Config::get('community_store.digitalDownloadFileSet', 0));
+
             foreach ($files['ddfID'] as $fileID) {
                 if ($fileID) {
                     self::add($product, $fileID);
                     $fileObj = File::getByID($fileID);
-                    $fs = FileSet::getByName("Digital Downloads");
-                    $fs->addFileToSet($fileObj);
+                    if (is_object($fs)) {
+                        $fs->addFileToSet($fileObj);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added options to select custom customer group and digital download fileset

Install and upgrade take care of creating and saving ID for each.

I removed all references to the customer group and digital download fileset using getByName() to use getByID() instead

I added 2 tabs under settings: Customers and Digital Download.

The digital option which is currently under the cart and checkout tab could probably be moved to the new digital downloads tab