### PR TITLE
Orders filtering by payment methods

### DIFF
--- a/controllers/single_page/dashboard/store/orders.php
+++ b/controllers/single_page/dashboard/store/orders.php
@@ -11,12 +11,16 @@ use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Package\CommunityStore\Entity\Attribute\Key\StoreOrderKey;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order as StoreOrder;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderList as StoreOrderList;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as StorePaymentMethod;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderStatus\OrderStatus as StoreOrderStatus;
 
 class Orders extends DashboardPageController
 {
-    public function view($status = '')
+    public function view($status = '', $payment = '')
     {
+        if ($status == 'nostatus') {
+            $status = '';
+        }
         $orderList = new StoreOrderList();
 
         if ($this->request->query->get('keywords')) {
@@ -27,6 +31,10 @@ class Orders extends DashboardPageController
             $orderList->setStatus($status);
         }
 
+        if ($payment) {
+            $orderList->setPaymentMethods($payment);
+        }
+
         $orderList->setItemsPerPage(20);
 
         if (Config::get('community_store.showUnpaidExternalPaymentOrders')) {
@@ -35,6 +43,7 @@ class Orders extends DashboardPageController
 
         $factory = new PaginationFactory($this->app->make(Request::class));
         $paginator = $factory->createPaginationObject($orderList);
+        $enabledMethods = StorePaymentMethod::getEnabledMethods();
 
         $pagination = $paginator->renderDefaultView();
         $this->set('orderList', $paginator->getCurrentPageResults());
@@ -45,6 +54,9 @@ class Orders extends DashboardPageController
         $this->requireAsset('css', 'communityStoreDashboard');
         $this->requireAsset('javascript', 'communityStoreFunctions');
         $this->set('statuses', StoreOrderStatus::getAll());
+        $this->set('payment', $payment);
+        $this->set("enabledPaymentMethods", $enabledMethods);
+
 
         if ('all' == Config::get('community_store.shoppingDisabled')) {
             $this->set('shoppingDisabled', true);

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -236,8 +236,10 @@ $csm = $app->make('cs/helper/multilingual');
 
                                 <div class="col-sm-12">
                                     <?php foreach ($orderChoicesAttList as $ak) { ?>
-                                        <label><?= $ak->getAttributeKeyDisplayName()?></label>
-                                        <p class="store-summary-order-choices-<?= $ak->getAttributeKeyID()?>"></p>
+                                        <div id="store-att-display-<?= $ak->getAttributeKeyHandle(); ?>">
+                                            <label><?= $ak->getAttributeKeyDisplayName()?></label>
+                                            <p class="store-summary-order-choices-<?= $ak->getAttributeKeyID()?>"></p>
+                                        </div>
                                     <?php } ?>
                                 </div>
 

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -553,35 +553,60 @@ use \Concrete\Core\User\UserInfoRepository;
         <p class="alert alert-warning text-center"><?= t('Cart and Ordering features are currently disabled. This setting can be changed via the'); ?> <a href="<?= Url::to('/dashboard/store/settings#settings-checkout'); ?>"><?= t('settings page.'); ?></a></p>
     <?php } ?>
 
-    <div class="ccm-dashboard-content-inner">
-        <form role="form" class="form-inline ccm-search-fields ">
-            <div class="ccm-search-fields-row">
-                <?php if ($statuses) { ?>
-                    <ul id="group-filters" class="nav nav-pills">
-                        <li <?= (!$status ? 'class="active"' : ''); ?>><a href="<?= Url::to('/dashboard/store/orders/') ?>"><?= t('All Statuses') ?></a></li>
+    <div class="ccm-dashboard-content-full">
+        <form role="form" class="form-inline ccm-search-fields">
 
-                        <?php foreach ($statuses as $statusoption) { ?>
-                            <li <?= ($status == $statusoption->getHandle() ? 'class="active"' : ''); ?>><a href="<?= Url::to('/dashboard/store/orders/', $statusoption->getHandle()) ?>"><?= t($statusoption->getName()); ?></a></li>
-                        <?php } ?>
-                    </ul>
-                <?php } ?>
-            </div>
-            <br />
-
-            <div class="ccm-search-fields-row ccm-search-fields-submit">
-                <div class="form-group">
-                    <div class="ccm-search-main-lookup-field">
-                        <i class="fa fa-search"></i>
-                        <?= $form->search('keywords', $searchRequest['keywords'], ['placeholder' => t('Search Orders')]) ?>
+            <div class="ccm-search-fields-row row">
+                <div class="ccm-search-fields-submit col-xs-12 col-md-6">
+                    <div class="form-group">
+                        <div class="ccm-search-main-lookup-field">
+                            <i class="fa fa-search"></i>
+                            <?= $form->search('keywords', $searchRequest['keywords'], ['placeholder' => t('Search Orders')]) ?>
+                        </div>
                     </div>
+                    <button type="submit" class="btn btn-default"><?= t('Search') ?></button>
                 </div>
-                <button type="submit" class="btn btn-default"><?= t('Search') ?></button>
-            </div>
 
+                <div class="col-xs-12 col-md-6">
+                    <ul id="group-filters" class="nav nav-pills pull-right">
+                    <?php if($statuses){?>
+                        <li role="presentation" class="dropdown">
+                            <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                                <?= t('Order Status')?> <span class="caret"></span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li <?= (!$status ? 'class="active"' : ''); ?>><a href="<?= \URL::to('/dashboard/store/orders/')?>"><?= t('All Statuses')?></a></li>
+                                <?php foreach($statuses as $statusoption){ ?>
+                                    <li <?= ($status == $statusoption->getHandle() ? 'class="active"' : ''); ?>><a href="<?= \URL::to('/dashboard/store/orders/', $statusoption->getHandle())?>"><?= t($statusoption->getName());?></a></li>
+                                <?php } ?>
+                            </ul>
+                        </li>
+                    <?php } ?>
+    
+                    <?php if($enabledPaymentMethods){?>
+                        <li role="presentation" class="dropdown">
+                            <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                                <?= t('Payment Method')?> <span class="caret"></span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li <?= (!$enabledPaymentMethods ? 'class="active"' : ''); ?>><a href="<?= \URL::to('/dashboard/store/orders/')?>"><?= t('All Payment Methods')?></a></li>
+                                <?php foreach($enabledPaymentMethods as $paymentmethod){ ?>
+                                    <li <?= ($payment == $paymentmethod->getHandle() ? 'class="active"' : ''); ?>><a href="<?= \URL::to('/dashboard/store/orders/nostatus/', $paymentmethod->getHandle())?>"><?= t($paymentmethod->getName());?></a></li>
+                                <?php } ?>
+                            </ul>
+                        </li>
+                    <?php } ?>
+                </ul>
+                </div>
+            </div>
         </form>
 
+        <?php 
+
+        //var_dump($orderList, true); 
+
+        ?>
         <?php if (!empty($orderList)) { ?>
-            <div class="ccm-dashboard-content-full">
             <table class="ccm-search-results-table">
                 <thead>
                 <tr>
@@ -669,9 +694,10 @@ use \Concrete\Core\User\UserInfoRepository;
                 <?php } ?>
                 </tbody>
             </table>
-            </div>
         <?php } ?>
     </div>
+    
+
 
     <?php if (empty($orderList)) { ?>
         <br/><p class="alert alert-info"><?= t('No Orders Found'); ?></p>

--- a/src/CommunityStore/Order/OrderList.php
+++ b/src/CommunityStore/Order/OrderList.php
@@ -152,23 +152,10 @@ class OrderList extends AttributedItemList
         $this->status = $status;
     }
 
-
-
-    /**
-        CAHUEYA MOD BEGIN
-    */
-
     public function setPaymentMethods($payment)
     {
         $this->payment = $payment;
     }
-
-
-    /**
-        CAHUEYA MOD END
-    */
-
-
 
     public function setIncludeExternalPaymentRequested($bool)
     {

--- a/src/CommunityStore/Order/OrderList.php
+++ b/src/CommunityStore/Order/OrderList.php
@@ -58,8 +58,26 @@ class OrderList extends AttributedItemList
                 $orderIDs[] = $value['oID'];
             }
 
+            if (!empty($orderIDs)) {
+                if ($paramcount > 0) {
+                    $this->query->andWhere('o.oID in (' . implode(',', $orderIDs) . ')');
+                } else {
+                    $this->query->where('o.oID in (' . implode(',', $orderIDs) . ')');
+                }
+            } else {
+                $this->query->where('1 = 0');
+            }
+        }
 
+        if (isset($this->payment)) {
+            $app = Application::getFacadeApplication();
+            $db = $app->make('database')->connection();
+            $matchingOrders = $db->query("SELECT oID FROM CommunityStoreOrders WHERE pmID IN (SELECT pmID FROM CommunityStorePaymentMethods WHERE pmHandle=?)", [$this->payment]);
 
+            $orderIDs = [];
+            while ($value = $matchingOrders->fetchRow()) {
+                $orderIDs[] = $value['oID'];
+            }
             if (!empty($orderIDs)) {
                 if ($paramcount > 0) {
                     $this->query->andWhere('o.oID in (' . implode(',', $orderIDs) . ')');
@@ -133,6 +151,24 @@ class OrderList extends AttributedItemList
     {
         $this->status = $status;
     }
+
+
+
+    /**
+        CAHUEYA MOD BEGIN
+    */
+
+    public function setPaymentMethods($payment)
+    {
+        $this->payment = $payment;
+    }
+
+
+    /**
+        CAHUEYA MOD END
+    */
+
+
 
     public function setIncludeExternalPaymentRequested($bool)
     {


### PR DESCRIPTION
This PR introduces the possibility to filter the OrderList by payment methods, just like it can be filtered by status of the orders already.

Instead of a button nav, this is now handled by two dropdown lists, one for OrderStatus, one for PaymentMethods and I inlined the search box to reduce the header size.

The menu gets the installed PaymentMethods that are available and enabled and populates the Nav with them. The selected payment method gets appended to the URL which will then be used for filtering. I have added this as a second parameter to the view function which is filled with a blank "nostatus"  value if no OrderStatus is selected for. You can filter by Status and PaymentMethod together and use a search phrase as well as only filter for one of the options.