### PR TITLE
Set the manufactures id when editing a page

### DIFF
--- a/controllers/single_page/dashboard/store/manufacturers.php
+++ b/controllers/single_page/dashboard/store/manufacturers.php
@@ -49,6 +49,7 @@ class Manufacturers extends DashboardPageController
         $this->set('pageTitle', t('Edit Manufacturer'));
         $manufacturer = Manufacturer::getByID($id);
         $this->set('manufacturer', $manufacturer);
+        $this->set('mID', $id);
     }
 
     public function submit()


### PR DESCRIPTION
The delete and edit button when editing a manufacturer was not showing. The id was not being set.