### PR TITLE
Address Warnings Shown During Schema Validation

### DIFF
--- a/src/CommunityStore/Order/OrderItem.php
+++ b/src/CommunityStore/Order/OrderItem.php
@@ -29,7 +29,7 @@ class OrderItem
     protected $pID;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order")
+     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order", inversedBy="orderItems")
      * @ORM\JoinColumn(name="oID", referencedColumnName="oID", onDelete="CASCADE")
      */
     protected $order;

--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -338,7 +338,7 @@ class Product
     }
 
     /**
-     * @ORM\OneToMany(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductPriceTier", mappedBy="product",cascade={"persist"}))
+     * @ORM\OneToMany(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductPriceTier", mappedBy="product", cascade={"persist"}))
      * @ORM\OrderBy({"ptFrom" = "ASC"})
      */
     protected $priceTiers;

--- a/src/CommunityStore/Product/ProductGroup.php
+++ b/src/CommunityStore/Product/ProductGroup.php
@@ -35,7 +35,7 @@ class ProductGroup
     protected $gID;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Group\Group")
+     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Group\Group", inversedBy="products")
      * @ORM\JoinColumn(name="gID", referencedColumnName="gID", onDelete="CASCADE")
      */
     protected $group;

--- a/src/CommunityStore/Product/ProductPriceTier.php
+++ b/src/CommunityStore/Product/ProductPriceTier.php
@@ -23,7 +23,7 @@ class ProductPriceTier
     protected $pID;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product",inversedBy="userGroups",cascade={"persist"})
+     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product", inversedBy="priceTiers", cascade={"persist"})
      * @ORM\JoinColumn(name="pID", referencedColumnName="pID", onDelete="CASCADE")
      */
     protected $product;

--- a/src/CommunityStore/Product/ProductVariation/ProductVariationOptionItem.php
+++ b/src/CommunityStore/Product/ProductVariation/ProductVariationOptionItem.php
@@ -23,7 +23,7 @@ class ProductVariationOptionItem
     protected $variation;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductOption\ProductOptionItem")
+     * @ORM\ManyToOne(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductOption\ProductOptionItem", inversedBy="variationoptionitems")
      * @ORM\JoinColumn(name="poiID", referencedColumnName="poiID", onDelete="CASCADE")
      */
     protected $option;


### PR DESCRIPTION
This changeset clears up some angry, red warnings being shown when the command `concrete5 orm:validate-schema` is executed.