### PR TITLE
Add Browser user agent to order

### DIFF
--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -198,6 +198,7 @@ class Settings extends DashboardPageController
                 Config::save('community_store.showUnpaidExternalPaymentOrders', $args['showUnpaidExternalPaymentOrders']);
                 Config::save('community_store.numberOfOrders', $args['numberOfOrders']);
                 Config::save('community_store.download_expiry_hours', $args['download_expiry_hours']);
+                Config::save('community_store.logUserAgent', $args['logUserAgent']);
 
                 //save payment methods
                 if ($args['paymentMethodHandle']) {

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -198,7 +198,7 @@ class Settings extends DashboardPageController
                 Config::save('community_store.showUnpaidExternalPaymentOrders', $args['showUnpaidExternalPaymentOrders']);
                 Config::save('community_store.numberOfOrders', $args['numberOfOrders']);
                 Config::save('community_store.download_expiry_hours', $args['download_expiry_hours']);
-                Config::save('community_store.logUserAgent', $args['logUserAgent']);
+                Config::save('community_store.logUserAgent', (bool) $args['logUserAgent']);
 
                 //save payment methods
                 if ($args['paymentMethodHandle']) {

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -321,6 +321,11 @@ use \Concrete\Core\User\UserInfoRepository;
         if ($locale) { ?>
             <br /><p><strong><?= t("Order Locale") ?>: </strong><?= \Punic\Language::getName($locale) ?></p>
         <?php } ?>
+        
+        <?php $userAgent = $order->getUserAgent();
+        if ($userAgent) { ?>
+            <br /><p><strong><?= t("Browser User Agent") ?>: </strong><?= $userAgent ?></p>
+        <?php } ?>
 
         
     </fieldset>

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -559,6 +559,14 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                 <?= $form->label('numberOfOrders', t('Number of orders displayed per page on orders dashboard page')); ?>
                <?= $form->select('numberOfOrders', array(20 => 20, 50 => 50, 100 => 100, 500 => 500), Config::get('community_store.numberOfOrders'), array('style' => 'width: 125px;'))?>
             </div>
+            
+             <div class="checkbox">
+                <label>
+                    <?= $form->checkbox('logUserAgent', '1', (bool) Config::get('community_store.logUserAgent')) ?>
+                    <?= t('Log User Agent') ?>
+                    <span class="small text-muted"><br /><?= t('Log the user agent against the order (this will effect your GDPR compliance).') ?></span>
+                </label>
+            </div>
 
         </div>
 

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -564,7 +564,8 @@ class Order
         $order->setTaxIncluded($taxIncludedTotal);
         $order->setTaxLabels($taxLabels);
         $order->setTotal($total);
-        $order->setUserAgent($userAgent);
+        
+        Config::get('community_store.logUserAgent') ? $order->setUserAgent($userAgent) : '';
 
         $order->setLocale(Localization::activeLocale());
 

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -124,6 +124,9 @@ class Order
 
     /** @ORM\Column(type="string", nullable=true) */
     protected $locale;
+    
+    /** @ORM\Column(type="string", nullable=true) */
+    protected $userAgent;
 
     /**
      * @ORM\OneToMany(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderItem", mappedBy="order",cascade={"persist"}))
@@ -384,6 +387,16 @@ class Order
     public function setLocale($locale)
     {
         $this->locale = $locale;
+    }
+    
+    public function getUserAgent()
+    {
+        return $this->userAgent;
+    }
+
+    public function setUserAgent($userAgent)
+    {
+        $this->userAgent = $userAgent;
     }
 
     public function getTaxes()

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -509,6 +509,8 @@ class Order
     {
         $app = Application::getFacadeApplication();
         $csm = $app->make('cs/helper/multilingual');
+        
+        $userAgent = session::get('CLIENT_HTTP_USER_AGENT');
 
         $customer = new StoreCustomer();
         $now = new \DateTime();
@@ -562,6 +564,7 @@ class Order
         $order->setTaxIncluded($taxIncludedTotal);
         $order->setTaxLabels($taxLabels);
         $order->setTotal($total);
+        $order->setUserAgent($userAgent);
 
         $order->setLocale(Localization::activeLocale());
 


### PR DESCRIPTION
I've had a couple of issues where it would have been useful to see what browser / device was used when the order was placed.

This pull request adds the user agent to the order table. This is visible in the order summary page within the dashboard. 