### PR TITLE
Add the ability to sort shipping methods

### DIFF
--- a/controllers/single_page/dashboard/store/settings/shipping.php
+++ b/controllers/single_page/dashboard/store/settings/shipping.php
@@ -53,7 +53,7 @@ class Shipping extends DashboardPageController
                 if ($shippingMethod) {
                     $shippingMethodTypeMethod = $shippingMethod->getShippingMethodTypeMethod();
                     $shippingMethodTypeMethod->update($this->request->request->all());
-                    $shippingMethod->update($this->request->request->get('methodName'), $this->request->request->get('methodEnabled'), $this->request->request->get('methodDetails'));
+                    $shippingMethod->update($this->request->request->get('methodName'), $this->request->request->get('methodEnabled'), $this->request->request->get('methodDetails'), $this->request->request->get('methodSortOrder'));
                     $this->flash('success', t('Shipping Method Updated'));
 
                     return Redirect::to('/dashboard/store/settings/shipping');
@@ -65,7 +65,7 @@ class Shipping extends DashboardPageController
                 $shippingMethodType = StoreShippingMethodType::getByID($this->request->request->get('shippingMethodTypeID'));
                 $shippingMethodTypeMethod = $shippingMethodType->addMethod($this->request->request->all());
                 //make a shipping method that correlates with it.
-                StoreShippingMethod::add($shippingMethodTypeMethod, $shippingMethodType, $this->request->request->get('methodName'), true, $this->request->request->get('methodDetails'));
+                StoreShippingMethod::add($shippingMethodTypeMethod, $shippingMethodType, $this->request->request->get('methodName'), true, $this->request->request->get('methodDetails'), $this->request->request->get('methodSortOrder'));
                 $this->flash('success', t('Shipping Method Created'));
 
                 return Redirect::to('/dashboard/store/settings/shipping');

--- a/single_pages/dashboard/store/settings/shipping.php
+++ b/single_pages/dashboard/store/settings/shipping.php
@@ -29,10 +29,16 @@ if(in_array($controller->getAction(),$addViews)){
                         <?= $form->text('methodName',is_object($sm)?$sm->getName():''); ?>
                     </div>
                 </div>
-                <div class="col-xs-12 col-sm-6">
+                <div class="col-xs-12 col-sm-3">
                     <div class="form-group">
                         <?= $form->label('methodEnabled',t("Enabled")); ?>
                         <?= $form->select('methodEnabled',array(true=>t('Yes'),false=>t('No')),is_object($sm)?$sm->isEnabled():''); ?>
+                    </div>
+                </div>
+                <div class="col-xs-12 col-sm-3">
+                    <div class="form-group">
+                        <?= $form->label('methodSortOrder',t("Sort Order")); ?>
+                        <?= $form->text('methodSortOrder',is_object($sm)?$sm->getSortOrder():''); ?>
                     </div>
                 </div>
                 <div class="col-xs-12 col-sm-12">
@@ -100,6 +106,7 @@ if(in_array($controller->getAction(),$addViews)){
                     <tr>
                         <th><?= t("%s Methods", $methodType->getMethodTypeController()->getShippingMethodTypeName()) ?></th>
                         <th style="width: 20%;"><?= t("Enabled") ?></th>
+                        <th style="width: 20%;"><?= t("Sort Order") ?></th>
                         <th class="text-right" style="width: 20%;"><?= t("Actions") ?></th>
                     </tr>
                     </thead>
@@ -113,6 +120,7 @@ if(in_array($controller->getAction(),$addViews)){
                             <tr>
                                 <td><?= $method->getName() ?></td>
                                 <td style="width: 20%;"><?= $method->isEnabled() ? t('Yes') : t('No') ?></td>
+                                <td style="width: 20%;"><?= $method->getSortOrder() ?></td>
                                 <td class="text-right" style="width: 20%;">
                                     <a href="<?= Url::to('/dashboard/store/settings/shipping/edit', $method->getID()) ?>"
                                        class="btn btn-default"><?= t("Edit") ?></a>

--- a/src/CommunityStore/Shipping/Method/ShippingMethod.php
+++ b/src/CommunityStore/Shipping/Method/ShippingMethod.php
@@ -44,6 +44,11 @@ class ShippingMethod
      */
     protected $smEnabled;
 
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    protected $smSortOrder;
+
     protected $smOfferKey;
 
     public function setOfferKey($key)
@@ -83,6 +88,11 @@ class ShippingMethod
     public function setDetails($details)
     {
         $this->smDetails = $details;
+    }
+
+    public function setSortOrder($smSortOrder)
+    {
+        $this->smSortOrder = $smSortOrder;
     }
 
     public function getID()
@@ -142,6 +152,11 @@ class ShippingMethod
         return $this->smEnabled;
     }
 
+    public function getSortOrder()
+    {
+        return $this->smSortOrder;
+    }
+
     public static function getByID($smID)
     {
         $ident = explode('_', $smID);
@@ -167,7 +182,7 @@ class ShippingMethod
         if ($methodTypeID) {
             $methods = $em->getRepository(get_called_class())->findBy(['smtID' => $methodTypeID, 'smEnabled' => '1']);
         } else {
-            $methods = $em->createQuery('select sm from \Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethod sm where sm.smEnabled = 1')->getResult();
+            $methods = $em->createQuery('select sm from \Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethod sm where sm.smEnabled = 1 order by sm.smSortOrder')->getResult();
         }
 
         return $methods;
@@ -193,7 +208,7 @@ class ShippingMethod
      *
      * @ORM\return ShippingMethod
      */
-    public static function add($smtm, $smt, $smName, $smEnabled, $smDetails)
+    public static function add($smtm, $smt, $smName, $smEnabled, $smDetails, $smSortOrder)
     {
         $sm = new self();
         $sm->setShippingMethodTypeMethodID($smtm);
@@ -201,6 +216,7 @@ class ShippingMethod
         $sm->setName($smName);
         $sm->setEnabled($smEnabled);
         $sm->setDetails($smDetails);
+        $sm->setSortOrder($smSortOrder);
         $sm->save();
         $smtm->setShippingMethodID($sm->getID());
         $smtm->save();
@@ -208,10 +224,11 @@ class ShippingMethod
         return $sm;
     }
 
-    public function update($smName, $smEnabled, $smDetails)
+    public function update($smName, $smEnabled, $smDetails, $smSortOrder)
     {
         $this->setName($smName);
         $this->setEnabled($smEnabled);
+        $this->setSortOrder($smSortOrder);
         $this->setDetails($smDetails);
         $this->save();
 


### PR DESCRIPTION
This Pull request, gives you more control over the shipping methods on the checkout page.
You can now choose what order they show, this is set within the dashboard shipping methods page.
