### PR TITLE
Add "Electronic Delivery Fee" Surcharge (as Shipping Method)

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -178,6 +178,10 @@ class Controller extends Package
         if (is_object($shippingMethodType)) {
             $shippingMethodType->delete();
         }
+        $shippingMethodType = ShippingMethodType::getByHandle('electronic_delivery_fee');
+        if (is_object($shippingMethodType)) {
+            $shippingMethodType->delete();
+        }
 
         // change existing product pages back to standard page type to prevent broken pages
         $list = new \Concrete\Core\Page\PageList();

--- a/elements/shipping_method_types/electronic_delivery_fee/dashboard_form.php
+++ b/elements/shipping_method_types/electronic_delivery_fee/dashboard_form.php
@@ -1,0 +1,38 @@
+<?php 
+defined('C5_EXECUTE') or die("Access Denied.");
+extract($vars); ?>
+
+
+<div class="row">
+    <div class="col-xs-12 col-sm-6">
+        <div class="form-group">
+            <?= $form->label('fixedRate',t("Fixed Rate")); ?>
+            <?= $form->text('fixedRate',$smtm->getFixedRate()); ?>
+        </div>
+    </div>
+    <div class="col-xs-12 col-sm-6">
+        <div class="form-group">
+            <?= $form->label('percentageRate',t("Percentage Rate")); ?>
+            <?= $form->text('percentageRate',$smtm->getPercentageRate()); ?>
+        </div>
+    </div>
+</div>  
+<div class="row">
+    <div class="col-xs-12 col-sm-6">
+        <div class="form-group">
+            <?= $form->label('countries',t("Which Countries does this Apply to?")); ?>
+            <?= $form->select('countries',array('all'=>t("All Countries"),'selected'=>t("Certain Countries")),$smtm->getCountries()); ?>
+        </div>
+    </div>
+    <div class="col-xs-12 col-sm-6">
+        <div class="form-group">
+            <?= $form->label('countriesSelected',t("If Certain Countries, which?")); ?>
+            <select class="form-control" multiple name="countriesSelected[]">
+                <?php $selectedCountries = explode(',',$smtm->getCountriesSelected()); ?>
+                <?php foreach($countryList as $code=>$country){?>
+                    <option value="<?= $code?>"<?php if(in_array($code,$selectedCountries)){echo " selected";}?>><?= $country?></option>
+                <?php } ?>
+            </select>
+        </div>
+    </div>
+</div> 

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -95,7 +95,7 @@ class Order
     /** @ORM\Column(type="decimal", precision=10, scale=2) */
     protected $oTotal;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /** @ORM\Column(type="text", nullable=true) */
     protected $transactionReference;
 
     /** @ORM\Column(type="datetime", nullable=true) */

--- a/src/CommunityStore/Shipping/Method/Types/ElectronicDeliveryFeeShippingMethod.php
+++ b/src/CommunityStore/Shipping/Method/Types/ElectronicDeliveryFeeShippingMethod.php
@@ -1,0 +1,229 @@
+<?php
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\Types;
+
+use Doctrine\ORM\Mapping as ORM;
+use Concrete\Core\Support\Facade\DatabaseORM as dbORM;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethodTypeMethod;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product as StoreProduct;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Cart\Cart as StoreCart;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Calculator as StoreCalculator;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Customer\Customer as StoreCustomer;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethodOffer as StoreShippingMethodOffer;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="CommunityStoreElectronicDeliveryFeeMethods")
+ */
+class ElectronicDeliveryFeeShippingMethod extends ShippingMethodTypeMethod
+{
+    /**
+     * @ORM\Column(type="float", nullable=true)
+     */
+    protected $fixedRate;
+    /**
+     * @ORM\Column(type="float",nullable=true)
+     */
+    protected $percentageRate;
+    /**
+     * @ORM\Column(type="string")
+     */
+    protected $countries;
+    /**
+     * @ORM\Column(type="text",nullable=true)
+     */
+    protected $countriesSelected;
+
+
+
+    public function setFixedRate($fixedRate)
+    {
+        $this->fixedRate = $fixedRate > 0 ? $fixedRate : null;
+    }
+
+    public function setPercentageRate($percentageRate)
+    {
+        $this->percentageRate = $percentageRate > 0.00 ? $percentageRate : null;
+    }
+
+    public function setCountries($countries)
+    {
+        $this->countries = $countries;
+    }
+
+    public function setCountriesSelected($countriesSelected)
+    {
+        $this->countriesSelected = $countriesSelected;
+    }
+    
+    
+
+    public function getFixedRate()
+    {
+        return $this->fixedRate;
+    }
+
+    public function getPercentageRate()
+    {
+        return $this->percentageRate;
+    }
+
+    public function getCountries()
+    {
+        return $this->countries;
+    }
+
+    public function getCountriesSelected()
+    {
+        return $this->countriesSelected;
+    }
+
+    public function addMethodTypeMethod($data)
+    {
+        return $this->addOrUpdate('add', $data);
+    }
+
+    public function update($data)
+    {
+        return $this->addOrUpdate('update', $data);
+    }
+
+    private function addOrUpdate($type, $data)
+    {
+        if ("update" == $type) {
+            $sm = $this;
+        } else {
+            $sm = new self();
+        }
+        
+        $sm->setFixedRate($data['fixedRate']);
+        $sm->setPercentageRate($data['percentageRate']);
+        $sm->setCountries($data['countries']);
+        
+        if ($data['countriesSelected']) {
+            $countriesSelected = implode(',', $data['countriesSelected']);
+        }
+        
+        $sm->setCountriesSelected($countriesSelected);
+
+        $em = dbORM::entityManager();
+        $em->persist($sm);
+        $em->flush();
+
+        return $sm;
+    }
+
+    public function dashboardForm($shippingMethod = null)
+    {
+        $app = Application::getFacadeApplication();
+        
+        $this->set('form', $app->make("helper/form"));
+        $this->set('smt', $this);
+        $this->set('countryList', $app->make('helper/lists/countries')->getCountries());
+
+        if (is_object($shippingMethod)) {
+            $smtm = $shippingMethod->getShippingMethodTypeMethod();
+        } else {
+            $smtm = new self();
+        }
+        
+        $this->set("smtm", $smtm);
+    }
+
+    public function validate($args, $e)
+    {
+        if ( ("" == $args['fixedRate']) && ("" == $args['percentageRate']) ) {
+            $e->add(t("Fixed Rate and Percentage Rate cannot both be unset."));
+        }
+        
+        if ( ("" == !$args['fixedRate']) && (! is_numeric($args['fixedRate'])) ) {
+            $e->add(t("Fixed Rate should be a number."));
+        }
+        
+        if ( ("" == !$args['percentageRate']) && (! is_numeric($args['percentageRate'])) ) {
+            $e->add(t("Percentage Rate should be a number."));
+        }
+        
+        return $e;
+    }
+
+    public function isEligible()
+    {
+        //three checks - within countries, price range, and weight
+        return ( ($this->isWithinSelectedCountries())
+        //  &&   ($this->isWithinRange()) // TODO: Should still check to make sure order amount is valid, e.g., more than the fixed rate.
+            &&   (StoreCart::getCartWeight() == 0) );
+    }
+
+    // TODO: Should check to make sure order amount is valid, e.g., more than the fixed rate.
+    // public function isWithinRange()
+    // {
+    //     $subtotal = StoreCalculator::getSubTotal();
+    //     return ($subtotal >= something_or_some_calculation)
+    // }
+
+    public function isWithinSelectedCountries()
+    {
+        $customer = new StoreCustomer();
+        $custCountry = $customer->getValue('shipping_address')->country;
+        if ('all' != $this->getCountries()) {
+            $selectedCountries = explode(',', $this->getCountriesSelected());
+            if (in_array($custCountry, $selectedCountries)) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
+
+    private function getRate()
+    {
+        // TODO: Add property for electronic deliverability
+        // $shippableItems = StoreCart::getShippableItems();
+        
+        //if (count($shippableItems) == 0) {
+        //    return 0;
+        //}
+        
+        $orderSubTotal  = StoreCalculator::getSubTotal();
+        $fixedRate      = $this->getFixedRate();
+        $percentageRate = $this->getPercentageRate();
+
+        // TODO: Add property for electronic deliverability
+        // foreach ($shippableItems as $item) {
+        //     //check if item is shippable
+        //     $product = StoreProduct::getByID($item['product']['pID']);
+        //     if ($product->isShippable()) {
+        //         $totalQty = $totalQty + $item['product']['qty'];
+        //     }
+        // }
+        
+        $deliveryFeeTotal = ( (($orderSubTotal + $fixedRate) / (1 - $percentageRate)) - $orderSubTotal );
+
+        return $deliveryFeeTotal;
+    }
+
+    public function getShippingMethodTypeName()
+    {
+        return t('Electronic Delivery Fee');
+    }
+
+    public function getOffers()
+    {
+        $offers = [];
+
+        $offer = new StoreShippingMethodOffer();
+        $offer->setRate($this->getRate());
+
+        $offers[] = $offer;
+
+        return $offers;
+    }
+
+    public function getOffer($key)
+    {
+        $this->getOffers()[$key];
+    }
+}

--- a/src/CommunityStore/Utilities/Installer.php
+++ b/src/CommunityStore/Utilities/Installer.php
@@ -158,6 +158,7 @@ class Installer
     {
         self::installShippingMethod('flat_rate', 'Flat Rate', $pkg);
         self::installShippingMethod('free_shipping', 'Free Shipping', $pkg);
+        self::installShippingMethod('electronic_delivery_fee', 'Electronic Delivery Fee', $pkg);
     }
 
     public static function installShippingMethod($handle, $name, $pkg)


### PR DESCRIPTION
To facilitate sales via Square, and allow the processing fees to be accurately applied to an order, I've implemented the concept of an "Electronic Delivery Fee," implemented as a Shipping Method.  This approach applies the surcharge to the entire order, which is appropriate for assessing per-transaction payment processing fees.

An Electronic Delivery Fee can be configured to apply both a fixed rate and a percentage of the order total.  In the example below, Square's online transaction fee (30¢ + 2.9%) will be applied.

![image](https://user-images.githubusercontent.com/1233992/72582982-91d1c780-38b2-11ea-8102-bca9483237d1.png)

I'm sure that there are plenty of edge cases that I haven't considered and other areas for improvement (e.g., it's an odd user experience to have this show up as "Shipping"... could possibly implement this as a new "Processing" surcharge at the same level as Shipping and Tax), however, "the perfect is the enemy of the good."  I've already put this code into production for several sales scenarios, including event registrations and merchandise sales, and it definitely got the job done.