### PR TITLE
Two new events on_community_store_before_payment_complete and on_comm…

### DIFF
--- a/src/CommunityStore/Order/OrderEvent.php
+++ b/src/CommunityStore/Order/OrderEvent.php
@@ -9,8 +9,14 @@ class OrderEvent extends StoreEvent
     const ORDER_PLACED = 'on_community_store_order';
     const ORDER_STATUS_UPDATE = 'on_community_store_order_status_update';
     const ORDER_PAYMENT_COMPLETE = 'on_community_store_payment_complete';
+    const ORDER_BEFORE_PAYMENT_COMPLETE = 'on_community_store_before_payment_complete';
+    const ORDER_BEFORE_USER_ADD = 'on_community_store_before_user_add';
 
     protected $event;
+
+    protected $userData;
+
+    protected $userDataUpdated = false;
 
     protected $notificationEmails;
 
@@ -39,4 +45,25 @@ class OrderEvent extends StoreEvent
     {
         return $this->previousStatusHandle;
     }
+
+	/**
+	 * @param $data array
+	 */
+    public function updateUserData($data){
+    	$this->userData = $data;
+    	$this->userDataUpdated = true;
+
+	}
+
+	/**
+	 * @return array | null
+	 */
+	public function getUserData(){
+		return $this->userData;
+	}
+
+	public function userDataUpdated() {
+    	return $this->userDataUpdated;
+	}
+
 }


### PR DESCRIPTION
Two new events:
on_community_store_before_payment_complete and on_community_store_before_user_add.

on_community_store_before_user_add allows the username and password to be changed by the event listener thus allowing custom mechanisms to be used.

on_community_store_before_payment_complete was added to get around the issue where a user is already in a group, and the usual group membership addition code doesn't work because the core only adds the user to the group if they're not already in it. If your group has a time limit on it, say if it's a membership product, you'd want to readmit the user into the group when they pay. This event allows members to be removed from the group before the code them adds them back in, effectively resetting the expiry date.