### PR TITLE
Bugfix for getAddress

### DIFF
--- a/src/CommunityStore/Customer/Customer.php
+++ b/src/CommunityStore/Customer/Customer.php
@@ -42,6 +42,10 @@ class Customer
     {
         if ($this->isGuest()) {
             $addressraw = Session::get('community_' . $handle);
+            
+            if (is_array($addressraw)) {
+                $addressraw = (object) $addressraw;
+            }
 
             return self::formatAddress($addressraw);
         } else {


### PR DESCRIPTION
The same kind of conversion should be done on the addressraw object as in the getValue function below. When Session::get returns an array, getAddress('billing_address') fails.