### PR TITLE
Assign img-responsive class to the product block primary image

### DIFF
--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -469,7 +469,7 @@ if (is_object($product) && $product->isActive()) {
                                 <a itemprop="image" href="<?= $imgObj->getRelativePath(); ?>"
                                    title="<?= h($imgObj->getTitle()); ?>"
                                    class="store-product-thumb text-center center-block">
-                                    <img src="<?= $thumb->src; ?>" title="<?= h($imgObj->getTitle()); ?>"
+                                    <img class="img-responsive" src="<?= $thumb->src; ?>" title="<?= h($imgObj->getTitle()); ?>"
                                          alt="<?= h($imgTitle); ?>">
                                 </a>
                             </div>


### PR DESCRIPTION
This commit adds the img-responsive class to the primary image in the product block, which stops large images overflowing their containers in Bootstrap themes.