### PR TITLE
Allow an event listener subscribing to the on_community_store_cart_pre_add event

### DIFF
--- a/controllers/single_page/cart.php
+++ b/controllers/single_page/cart.php
@@ -140,9 +140,11 @@ class Cart extends PageController
             $added = $result['added'];
 
             $error = 0;
+            $errorMsg = null;
 
             if ($result['error']) {
                 $error = 1;
+				$errorMsg = $result['errorMsg'];
             }
 
             $product = Product::getByID($data['pID']);
@@ -150,7 +152,7 @@ class Cart extends PageController
             $productdata['pName'] = $product->getName();
             $productdata['pID'] = $product->getID();
 
-            $returndata = ['quantity' => $data['quantity'], 'added' => $added, 'product' => $productdata, 'action' => 'add', 'error' => $error];
+            $returndata = ['quantity' => $data['quantity'], 'added' => $added, 'product' => $productdata, 'action' => 'add', 'error' => $error, 'errorMsg' => $errorMsg];
             echo json_encode($returndata);
         }
         exit();

--- a/elements/cart_modal.php
+++ b/elements/cart_modal.php
@@ -35,8 +35,17 @@ $csm = $app->make('cs/helper/multilingual');
                 <p class="alert alert-warning"><?= t('Due to stock levels your quantity has been limited');?></p>
             <?php } ?>
 
-            <?php if($actiondata['error']) { ?>
-                <p class="alert alert-warning"><?= t('An issue has occured adding the product to the cart. You may be missing required information.');?></p>
+            <?php if($actiondata['error']) {
+				?>
+                <p class="alert alert-warning">
+                    <?php
+                if ($actiondata['errorMsg']){
+                    echo $actiondata['errorMsg'];
+                } else {
+                    echo t('An issue has occured adding the product to the cart. You may be missing required information.');
+                }
+                ?>
+                </p>
             <?php } ?>
         <?php } ?>
 

--- a/src/CommunityStore/Cart/Cart.php
+++ b/src/CommunityStore/Cart/Cart.php
@@ -245,6 +245,9 @@ class Cart
 
         \Events::dispatch(CartEvent::CART_PRE_ADD, $event);
 
+        $error = $event->getError();
+        $errorMsg = $event->getErrorMsg();
+
         $customerPrice = false;
 
         if ($product->allowCustomerPrice()) {
@@ -453,7 +456,7 @@ class Cart
         \Events::dispatch(CartEvent::CART_ACTION, $event);
         \Events::dispatch(CartEvent::CART_POST_ADD, $event);
 
-        return ['added' => $added, 'error' => $error, 'exclusive' => $product->isExclusive(), 'removeexistingexclusive' => $removeexistingexclusive];
+        return ['added' => $added, 'error' => $error, 'errorMsg' => $errorMsg, 'exclusive' => $product->isExclusive(), 'removeexistingexclusive' => $removeexistingexclusive];
     }
 
     public static function checkForExistingCartItem($cartItem)

--- a/src/CommunityStore/Cart/CartEvent.php
+++ b/src/CommunityStore/Cart/CartEvent.php
@@ -16,6 +16,11 @@ class CartEvent extends StoreEvent {
     const CART_POST_CLEAR = 'on_community_store_cart_post_clear';
     const CART_ACTION = 'on_community_store_cart_action';
 
+    /** @var boolean */
+    private $error = false;
+
+    /** @var string */
+    private $errorMsg = null;
 
     /** @var Product */
     private $product;
@@ -58,4 +63,30 @@ class CartEvent extends StoreEvent {
         $this->data = $data;
         return $this;
     }
+
+	/**
+	 * @param string
+	 * @return void
+	 */
+	public function setErrorMsg($e)
+	{
+		$this->errorMsg = $e;
+		$this->error = true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getError()
+	{
+		return $this->error;
+	}
+
+	/**
+	 * @return null|string
+	 */
+	public function getErrorMsg()
+	{
+		return $this->errorMsg;
+	}
 }


### PR DESCRIPTION
This commit allows an event listener that subscribes to on_community_store_cart_pre_add to modify the event object to set an error condition and error message. The cart then checks for the error condition and if it's present, stops the product being added to the cart. This allows external code to run and custom logic to be used.

In the case I am working on at the moment, which is for a catering business with two physical locations offering contactless pickup, users can pick food from a location specific menu, and they may not mix between menus. My event listener will therefore refuse to add location A products when a location B product is in the cart and vice versa.
