### PR TITLE
FilterByAttribute cannot find StoreOrderKey Class

### DIFF
--- a/src/CommunityStore/Order/OrderList.php
+++ b/src/CommunityStore/Order/OrderList.php
@@ -9,6 +9,7 @@ use Concrete\Core\Search\ItemList\Database\AttributedItemList;
 use Concrete\Core\Search\Pagination\PaginationProviderInterface;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderItem;
+use Concrete\Package\CommunityStore\Entity\Attribute\Key\StoreOrderKey;
 
 class OrderList extends AttributedItemList implements PaginationProviderInterface
 {


### PR DESCRIPTION
use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderList;
$ol = new OrderList();
$ol->filterByAttribute('pickup_location', 2);

call_user_func_array() expects parameter 1 to be a valid callback, class 'Concrete\Package\CommunityStore\Src\CommunityStore\Order\StoreOrderKey' not found

Fixed by adding 
use Concrete\Package\CommunityStore\Entity\Attribute\Key\StoreOrderKey;

to OrderList



