### PR TITLE
fix product price so taxes are calculated accurately

### DIFF
--- a/src/CommunityStore/Tax/TaxRate.php
+++ b/src/CommunityStore/Tax/TaxRate.php
@@ -257,6 +257,10 @@ class TaxRate
                     $product->setVariation($cartItem['product']['variation']);
                 }
 
+                if($cartItem['priceAdjustment']){
+                    $product->setPriceAdjustment($cartItem['priceAdjustment']);
+                }
+
                 if (is_object($product)) {
                     if ($product->isTaxable()) {
                         //if this tax rate is in the tax class associated with this product


### PR DESCRIPTION
When a product is taxable and has configurable options that modify its price, taxes are calculated with the default price, I edited it so it works with the modified price.