### PR TITLE
Optional order notes field that can be enabled via settings

### DIFF
--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -143,6 +143,7 @@ class Checkout extends PageController
 
         $this->set('total', $totals['total']);
         $this->set('shippingEnabled', Cart::isShippable());
+        $this->set('orderNotesEnabled', Config::get('community_store.orderNotesEnabled') == 'true');
         $this->set('shippingInstructions', Cart::getShippingInstructions());
 
         $this->requireAsset('javascript', 'jquery');
@@ -313,6 +314,8 @@ class Checkout extends PageController
                 $customer = new Customer();
                 if ('billing' == $data['adrType']) {
                     $this->updateBilling($data);
+                    $notes = $data['notes'];
+                    if($notes) Session::set('notes', $notes);
                     $address = Session::get('billing_address');
                     $phone = Session::get('billing_phone');
                     $company = Session::get('billing_company');

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -143,7 +143,7 @@ class Checkout extends PageController
 
         $this->set('total', $totals['total']);
         $this->set('shippingEnabled', Cart::isShippable());
-        $this->set('orderNotesEnabled', Config::get('community_store.orderNotesEnabled') == 'true');
+        $this->set('orderNotesEnabled', Config::get('community_store.orderNotesEnabled'));
         $this->set('shippingInstructions', Cart::getShippingInstructions());
 
         $this->requireAsset('javascript', 'jquery');

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -202,7 +202,7 @@ class Settings extends DashboardPageController
                 Config::save('community_store.guestCheckout', $args['guestCheckout']);
                 Config::save('community_store.companyField', $args['companyField']);
                 Config::save('community_store.shoppingDisabled', trim($args['shoppingDisabled']));
-                Config::save('community_store.orderNotesEnabled', trim($args['orderNotesEnabled']));
+                Config::save('community_store.orderNotesEnabled', (bool)trim($args['orderNotesEnabled']));
                 Config::save('community_store.placesAPIKey', trim($args['placesAPIKey']));
                 Config::save('community_store.checkout_scroll_offset', intval($args['checkoutScrollOffset']));
                 Config::save('community_store.receiptHeader', trim($args['receiptHeader']));

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -202,6 +202,7 @@ class Settings extends DashboardPageController
                 Config::save('community_store.guestCheckout', $args['guestCheckout']);
                 Config::save('community_store.companyField', $args['companyField']);
                 Config::save('community_store.shoppingDisabled', trim($args['shoppingDisabled']));
+                Config::save('community_store.orderNotesEnabled', trim($args['orderNotesEnabled']));
                 Config::save('community_store.placesAPIKey', trim($args['placesAPIKey']));
                 Config::save('community_store.checkout_scroll_offset', intval($args['checkoutScrollOffset']));
                 Config::save('community_store.receiptHeader', trim($args['receiptHeader']));

--- a/js/communityStore.js
+++ b/js/communityStore.js
@@ -612,6 +612,7 @@ $(document).ready(function() {
         var bCity = $("#store-checkout-billing-city").val();
         var bState = $("#store-checkout-billing-state").val();
         var bPostal = $("#store-checkout-billing-zip").val();
+        var notes = $("#store-checkout-notes").val();
         $("#store-checkout-form-group-billing .store-checkout-form-group-body .store-checkout-errors").remove();
 
         var ccm_token = $(this).find('[name=ccm_token]').val();
@@ -640,7 +641,8 @@ $(document).ready(function() {
                 count: bCountry,
                 city: bCity,
                 state: bState,
-                postal: bPostal
+                postal: bPostal,
+                notes: notes
             },
             success: function(result) {
                 //var test = null;

--- a/mail/new_order_notification.php
+++ b/mail/new_order_notification.php
@@ -147,6 +147,11 @@ ob_start();
                 <strong><?= t("Delivery Instructions") ?>: </strong><?= $shippingInstructions ?> <br />
             <?php } ?>
         <?php } ?>
+        <?php
+        $notes = $order->getNotes();
+        if ($notes) { ?>
+            <strong><?= t("Order notes") ?>: </strong><?= $notes ?> <br />
+        <?php } ?>
 
         <?php $applieddiscounts = $order->getAppliedDiscounts();
         if (!empty($applieddiscounts)) { ?>

--- a/mail/order_receipt.php
+++ b/mail/order_receipt.php
@@ -210,6 +210,11 @@ ob_start();
             } ?>
         <?php
         } ?>
+        <?php
+            $notes = $order->getNotes();
+            if ($notes) { ?>
+            <strong><?= t("Order notes"); ?>: </strong><?= $notes; ?> <br />
+        <?php } ?>
 
         <?php $applieddiscounts = $order->getAppliedDiscounts();
         if (!empty($applieddiscounts)) {

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -163,6 +163,17 @@ $csm = $app->make('cs/helper/multilingual');
                             </div>
                         </div>
 
+                        <?php if($orderNotesEnabled) { ?>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <label for="store-checkout-notes"><?= t("Order notes") ?></label>
+                                    <?= $form->textarea('store-checkout-notes', '', array('placeholder'=>t('Order notes'))); ?>
+                                </div>
+                            </div>
+                        </div>
+                        <?php } ?>
+
                         <div class="row">
                             <?php if ($shippingEnabled) { ?>
                             <div class="store-copy-billing-container col-md-12 text-right">

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -313,7 +313,11 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price;
             if ($shippingInstructions) { ?>
                 <p><strong><?= t("Delivery Instructions") ?>: </strong><?= h($shippingInstructions) ?></p>
             <?php } ?>
-
+            <?php
+            $notes = $order->getNotes();
+            if ($notes) { ?>
+                <p><strong><?= t("Order notes") ?>: </strong><?= h($notes) ?></p>
+            <?php } ?>
         <?php } ?>
 
         <?php $locale = $order->getLocale();

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -527,10 +527,9 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
             <h3><?= t('Order notes'); ?></h3>
             <div class="form-group">
-                <?php $orderNotesEnabled = Config::get('community_store.orderNotesEnabled');
-                ?>
-                <label><?= $form->radio('orderNotesEnabled', 'true', ('true' == $orderNotesEnabled)); ?> <?php echo t('Enabled'); ?></label><br />
-                <label><?= $form->radio('orderNotesEnabled', ' ', '' == $orderNotesEnabled); ?> <?php echo t('Disabled'); ?></label><br />
+                <label><?= $form->checkbox('orderNotesEnabled', true, Config::get('community_store.orderNotesEnabled')); ?>
+                    <?= t('Enable order notes field'); ?>
+                </label>
             </div>
 
             <div class="form-group">

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -525,6 +525,13 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
                 <label><?= $form->radio('shoppingDisabled', 'all', 'all' == $shoppingDisabled); ?> <?php echo t('Disabled (Catalog Mode)'); ?></label><br />
             </div>
 
+            <h3><?= t('Order notes'); ?></h3>
+            <div class="form-group">
+                <?php $orderNotesEnabled = Config::get('community_store.orderNotesEnabled');
+                ?>
+                <label><?= $form->radio('orderNotesEnabled', 'true', ('true' == $orderNotesEnabled)); ?> <?php echo t('Enabled'); ?></label><br />
+                <label><?= $form->radio('orderNotesEnabled', ' ', '' == $orderNotesEnabled); ?> <?php echo t('Disabled'); ?></label><br />
+            </div>
 
             <div class="form-group">
                 <?= $form->label('guestCheckout', t('Cart Open Style')); ?>

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -527,7 +527,7 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
             <h3><?= t('Order notes'); ?></h3>
             <div class="form-group">
-                <label><?= $form->checkbox('orderNotesEnabled', true, Config::get('community_store.orderNotesEnabled')); ?>
+                <label><?= $form->checkbox('orderNotesEnabled', '1', Config::get('community_store.orderNotesEnabled')); ?>
                     <?= t('Enable order notes field'); ?>
                 </label>
             </div>

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -127,7 +127,7 @@ class Order
     /** @ORM\Column(type="text",nullable=true) */
     protected $oRefundReason;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /** @ORM\Column(type="text", nullable=true) */
     protected $oNotes;
 
     /** @ORM\Column(type="datetime", nullable=true) */

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -127,6 +127,9 @@ class Order
     /** @ORM\Column(type="text",nullable=true) */
     protected $oRefundReason;
 
+    /** @ORM\Column(type="string", nullable=true) */
+    protected $oNotes;
+
     /** @ORM\Column(type="datetime", nullable=true) */
     protected $externalPaymentRequested;
 
@@ -417,6 +420,16 @@ class Order
         $this->userAgent = $userAgent;
     }
 
+    public function setNotes($notes)
+    {
+        $this->oNotes = $notes;
+    }
+
+    public function getNotes()
+    {
+        return $this->oNotes;
+    }
+
     public function getTaxes()
     {
         $taxes = [];
@@ -529,6 +542,7 @@ class Order
         $csm = $app->make('cs/helper/multilingual');
 
         $userAgent = session::get('CLIENT_HTTP_USER_AGENT');
+        $notes = session::get('notes');
 
         $customer = new Customer();
         $now = new \DateTime();
@@ -577,6 +591,7 @@ class Order
         $order->setShipmentID($sShipmentID);
         $order->setRateID($sRateID);
         $order->setShippingInstructions($sInstructions);
+        $order->setNotes($notes);
         $order->setShippingTotal($shippingTotal);
         $order->setTaxTotal($taxTotal);
         $order->setTaxIncluded($taxIncludedTotal);


### PR DESCRIPTION
This PR adds a Notes field to the order, and provides a setting in the Cart and Checkout section that can be used to enable it. When enabled, it is displayed as "Order notes" field in the billing address section.

Having a generic Order notes field is useful to a number of our merchants. Not all of them use shipping(in which case they could use delivery instructions field), so having a generic order notes field that is filled prior to the shipping-method selection phase is a useful addition.