### PR TITLE
Check for a shipping method element based on the shipping method's handle

### DIFF
--- a/elements/checkout/shipping_methods.php
+++ b/elements/checkout/shipping_methods.php
@@ -3,6 +3,7 @@
 use Illuminate\Filesystem\Filesystem;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethod;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethodType;
 
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 $eligibleMethods = ShippingMethod::getEligibleMethods();
@@ -13,13 +14,23 @@ $foundOffer = false;
 $csm = $app->make('cs/helper/multilingual');
 ?>
 
-<?php if (!empty($eligibleMethods)) { ?>
+<?php
+    /* @var $eligibleMethods ShippingMethod[] */
+    if (!empty($eligibleMethods)) { ?>
 
-    <?php foreach ($eligibleMethods as $method) { ?>
-        <?php if ($method->getPackageHandle() != 'community_store' && Filesystem::exists(DIR_BASE . "/packages/" . $method->getPackageHandle() . "/elements/checkout/shipping_methods.php")) { ?>
-            <?php View::element("checkout/shipping_methods", array('method' => $method), $method->getPackageHandle());
-                $foundOffer = true;
-            ?>
+    <?php foreach ($eligibleMethods as $method) {
+		$pkgHandle = $method->getPackageHandle();
+		$type = $method->getShippingMethodType();
+		$handle = $type->getHandle();
+        ?>
+		<?php if ($pkgHandle !== 'community_store' && Filesystem::exists(DIR_BASE . '/packages/' . $pkgHandle . '/elements/checkout/' .$handle. '_shipping_methods.php')) { ?>
+			<?php View::element('checkout/'.$handle.'_shipping_methods', array('method' => $method), $pkgHandle);
+			$foundOffer = true;
+			?>
+		<?php } elseif ($pkgHandle !== 'community_store' && Filesystem::exists(DIR_BASE . '/packages/' . $pkgHandle . '/elements/checkout/shipping_methods.php')) { ?>
+			<?php View::element('checkout/shipping_methods', array('method' => $method), $pkgHandle);
+			$foundOffer = true;
+			?>
         <?php } else { ?>
             <?php foreach($method->getOffers() as $offer) {
                 $foundOffer = true;

--- a/src/CommunityStore/Shipping/Method/ShippingMethodType.php
+++ b/src/CommunityStore/Shipping/Method/ShippingMethodType.php
@@ -109,6 +109,10 @@ class ShippingMethodType
         return $this->methodTypeController;
     }
 
+	/**
+	 * @param $smtID
+	 * @return ShippingMethodType
+	 */
     public static function getByID($smtID)
     {
         $em = dbORM::entityManager();
@@ -118,6 +122,10 @@ class ShippingMethodType
         return $obj;
     }
 
+	/**
+	 * @param $smtHandle
+	 * @return ShippingMethodType|null
+	 */
     public static function getByHandle($smtHandle)
     {
         $em = dbORM::entityManager();


### PR DESCRIPTION
and fall back to shipping_method.php if it's not found. This allows element overrides to work without inducing an endless loop and allows each shipping method to have a different layout and also to be overridden.