### PR TITLE
Add handle to order item option model

### DIFF
--- a/src/CommunityStore/Order/OrderItem.php
+++ b/src/CommunityStore/Order/OrderItem.php
@@ -364,6 +364,7 @@ class OrderItem
 
             $orderItemOption = new OrderItemOption();
             $orderItemOption->setOrderItemOptionKey($optionGroupName);
+            $orderItemOption->setOrderItemOptionHandle($optiongroup->getHandle());
             $orderItemOption->setOrderItemOptionValue($optionvalue);
             $orderItemOption->setOrderItem($orderItem);
             $orderItemOption->save();

--- a/src/CommunityStore/Order/OrderItemOption.php
+++ b/src/CommunityStore/Order/OrderItemOption.php
@@ -28,6 +28,11 @@ class OrderItemOption
     protected $oioKey;
 
     /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    protected $oioHandle;
+
+    /**
      * @ORM\Column(type="text")
      */
     protected $oioValue;
@@ -81,6 +86,14 @@ class OrderItemOption
     public function setOrderItemOptionKey($oioKey)
     {
         $this->oioKey = $oioKey;
+    }
+
+    /**
+     * @ORM\param mixed $oioHandle
+     */
+    public function setOrderItemOptionHandle($oioHandle)
+    {
+        $this->oioHandle = $oioHandle;
     }
 
     /**

--- a/src/CommunityStore/Order/OrderItemOption.php
+++ b/src/CommunityStore/Order/OrderItemOption.php
@@ -113,6 +113,14 @@ class OrderItemOption
     }
 
     /**
+     * @ORM\return mixed
+     */
+    public function getOrderItemOptionHandle()
+    {
+        return $this->oioHandle;
+    }
+
+    /**
      * @return mixed
      */
     public function getOrderItemOptionPriceAdjust()


### PR DESCRIPTION
It's good to have a handle on product option, but not having it on order item option means that you can only use the option name to process the options on the submitted orders, which defeats the purpose of having the handles. This PR adds a handle to order item option model and sets it to the handle of the product option. 