### PR TITLE
Add the ability to make select and radio fields required

### DIFF
--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -318,7 +318,7 @@ if (is_object($product) && $product->isActive()) {
 
                                     <?php if ('radio' != $displayType) {
                                     ?>
-                                    <select class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : ''; ?> form-control"
+                                    <select <?= $required ? ' required="required" ' : ''; ?> 'class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : ''; ?> form-control"
                                             name="po<?= $option->getID(); ?>">
                                         <?php
                                         } ?>
@@ -329,6 +329,7 @@ if (is_object($product) && $product->isActive()) {
                                         $outOfStock = false;
                                         $firstOptionItem = true;
                                         foreach ($optionItems as $optionItem) {
+                                            $noValue = false;
                                             if (!$optionItem->isHidden()) {
                                                 $variation = $variationLookup[$optionItem->getID()];
                                                 $selected = '';
@@ -342,8 +343,14 @@ if (is_object($product) && $product->isActive()) {
                                                         $selected = 'selected="selected"';
                                                     }
                                                 } else {
+                                                    $disabled = false;
                                                     if ($firstOptionItem) {
                                                         $selected = 'selected="selected"';
+                                                        if(!$optionItem->getName()) {
+                                                            $disabled = 'disabled="disabled" ';
+                                                            $noValue = true;
+                                                            if($displayType == 'radio') $selected = '';
+                                                        }
                                                         $firstOptionItem = false;
                                                     }
                                                 }
@@ -371,7 +378,7 @@ if (is_object($product) && $product->isActive()) {
                                                     </div>
                                                 <?php } else { ?>
                                                     <option
-                                                        <?= $disabled . ' ' . $selected; ?> value="<?= $optionItem->getID(); ?>"
+                                                        <?= $disabled . ' ' . $selected; ?> value="<?= $noValue && $required ? '' : $optionItem->getID(); ?>"
                                                                                     data-adjustment="<?= $optionItem->getPriceAdjustment($product->getDiscountRules()); ?>"
 
                                                     ><?= h($csm->t($optionLabel, $translateHandle, $product->getID(), $optionItem->getID())) . $outOfStock; ?></option>

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -280,7 +280,7 @@ if (!$productsPerRow) {
                                     <?php } ?>
 
                                     <?php if ($displayType != 'radio') { ?>
-                                    <select class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : ''; ?> form-control" name="po<?= $option->getID(); ?>">
+                                    <select <?= $required ? ' required="required" ' : ''; ?> class="store-product-option <?= $option->getIncludeVariations() ? 'store-product-variation' : ''; ?> form-control" name="po<?= $option->getID(); ?>">
                                         <?php } ?>
                                         <?php
                                         $firstAvailableVariation = false;
@@ -289,6 +289,7 @@ if (!$productsPerRow) {
                                         $outOfStock = false;
                                         $firstOptionItem = true;
                                         foreach ($optionItems as $optionItem) {
+                                            $noValue = false;
                                             if (!$optionItem->isHidden()) {
                                                 $variation = $variationLookup[$optionItem->getID()];
                                                 $selected = '';
@@ -302,8 +303,14 @@ if (!$productsPerRow) {
                                                         $selected = 'selected="selected"';
                                                     }
                                                 } else {
+                                                    $disabled = false;
                                                     if ($firstOptionItem) {
                                                         $selected = 'selected="selected"';
+                                                        if(!$optionItem->getName()) {
+                                                            $disabled = 'disabled="disabled" ';
+                                                            $noValue = true;
+                                                            if($displayType == 'radio') $selected = '';
+                                                        }
                                                         $firstOptionItem = false;
                                                     }
                                                 }
@@ -331,7 +338,7 @@ if (!$productsPerRow) {
                                                     </div>
                                                 <?php } else { ?>
                                                     <option <?= $disabled . ' ' . $selected; ?>
-                                                            value="<?= $optionItem->getID(); ?>"
+                                                            value="<?= $noValue && $required ? '' : $optionItem->getID(); ?>"
                                                             data-adjustment="<?= (float)$optionItem->getPriceAdjustment($product->getDiscountRules()); ?>"
                                                     ><?= h($csm->t($optionLabel, $translateHandle, $product->getID(), $optionItem->getID())) . $outOfStock; ?></option>
                                                 <?php } ?>

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -899,7 +899,7 @@ $dh = $app->make('helper/date');
                                 <% } else { %>
                                 <input type="hidden" value="0" name="poIncludeVariations[]"/>
                                 <% } %>
-                                <% if (poType != 'select' && poType != 'checkbox' && poType != 'static') { %>
+                                <% if (poType != 'checkbox' && poType != 'static') { %>
                                 <div class="col-xs-3">
                                     <div class="form-group">
                                         <label class="control-label"><?= t('Required'); ?></label>


### PR DESCRIPTION
The default behavior of select and radio options is to not have the 'required' option - the first option is always a selected one. However, it doesn't really work for bigger forms - people tend to just skip the fields that are already selected, and go directly to the "Add to cart" button, which leads to errors, since the form doesn't tell the user that he must select a certain field. The suggested fix changes the behavior in the following way:
1. Required field is available on the 'select' options.
2. When the required flag is set AND the first option value's name is empty, the 'required="required"' is added to select, the first option's value is set to an empty string, and the 'disabled' attribute is added to it(so the user couldn't select that empty option value). As a result, if that required flag is set on select and the first option is not empty, that option value is used as the default(no change from current behavior) - however, if it's set and the first option is empty, the browser will force the user to select it. And the select still by default displays the label for the first option.
3. In addition to those 2 conditions above(the required flag is set AND the first option value's name is empty), for the 'radio' display type, the 'selected' attribute is removed from the first option, as a result, the browser forces the user to pick up a value on radio button as well.