### PR TITLE
Add validation for shipping sort order.

### DIFF
--- a/controllers/single_page/dashboard/store/settings/shipping.php
+++ b/controllers/single_page/dashboard/store/settings/shipping.php
@@ -125,6 +125,10 @@ class Shipping extends DashboardPageController
             $e->add(t("Method Name must be set"));
         }
 
+        if (!is_numeric($data['methodSortOrder'])) {
+            $e->add(t("Sort order must be a number."));
+        }
+
         //pass the validator to the shipping method to check for it's own errors
         $shippingMethodType = ShippingMethodType::getByID($data['shippingMethodTypeID']);
         $e = $shippingMethodType->getMethodTypeController()->validate($data, $e);


### PR DESCRIPTION
Currently the field "Method Name" and "Base Price" field must be set to a number.

The "Sort Order" field could be included during form validation in the shipping controller.

The suggested fix would be to use is_numeric() to validate $data['methodSortOrder']