### PR TITLE
Change should be recorded when comment is present

### DIFF
--- a/src/CommunityStore/Order/OrderStatus/OrderStatusHistory.php
+++ b/src/CommunityStore/Order/OrderStatus/OrderStatusHistory.php
@@ -169,7 +169,10 @@ class OrderStatusHistory
                 $event = new OrderEvent($order, $previousStatus);
                 Events::dispatch(OrderEvent::ORDER_STATUS_UPDATE, $event);
             }
+        } else if(!empty($history) && $history[0]->getOrderStatusHandle() == $statusHandle && $comment) {
+            self::recordStatusChange($order, $statusHandle, $comment);
         }
+
     }
 
     private static function recordStatusChange(Order $order, $statusHandle, $comment = null)


### PR DESCRIPTION
Status change should be recorded when comment is present even when it's the same status, otherwise it's not possible to add a comment without changing the status.