### PR TITLE
Update orders.php

### DIFF
--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -377,7 +377,7 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price;
                         <?= $token->output('community_store'); ?>
                         <div class="row">
                             <div class="form-group col-md-6">
-                                <?= $form->select("orderStatus", $orderStatuses, $order->getStatus()); ?>
+                                <?= $form->select("orderStatus", $orderStatuses, $order->getStatusHandle()); ?>
                             </div>
                             <div class="form-group col-md-6">
                                 <?= $form->text("comment", ['placeholder' => 'Comment']); ?>


### PR DESCRIPTION
Bugfix - the selected value passed to $form->select should be a key in the $orderStatuses array, not the value, so it should be the handle of the order status, not it's name.