### PR TITLE
Prevent fatal error when cart item contains non-standard attributes

### DIFF
--- a/src/CommunityStore/Order/OrderItem.php
+++ b/src/CommunityStore/Order/OrderItem.php
@@ -360,14 +360,13 @@ class OrderItem
             $optiongroup = ProductOption::getByID($groupID);
             if ($optiongroup) {
                 $optionGroupName = $csm->t($optiongroup->getName(), 'optionName', null, $groupID);
+                $orderItemOption = new OrderItemOption();
+                $orderItemOption->setOrderItemOptionKey($optionGroupName);
+                $orderItemOption->setOrderItemOptionHandle($optiongroup->getHandle());
+                $orderItemOption->setOrderItemOptionValue($optionvalue);
+                $orderItemOption->setOrderItem($orderItem);
+                $orderItemOption->save();
             }
-
-            $orderItemOption = new OrderItemOption();
-            $orderItemOption->setOrderItemOptionKey($optionGroupName);
-            $orderItemOption->setOrderItemOptionHandle($optiongroup->getHandle());
-            $orderItemOption->setOrderItemOptionValue($optionvalue);
-            $orderItemOption->setOrderItem($orderItem);
-            $orderItemOption->save();
         }
 
         return $orderItem;


### PR DESCRIPTION
In case you want to submit something non-standard(not one of product options) along with the product-data in add-to-cart form(in order to e.g. use it in some way in cart observers), the data will be put into productAttributes array in cart item. However, when submitting the order, the cart-item-to-order-item conversion will fail because it can't find the corresponding product option. In the PR, the code that  adds the actual cart-item option is moved inside a block that verifies that a product option exists - this way, it's possible to have data in productAttributes in cart item that is not a part of product options, and during order submission, this data is simply ignored.