### PR TITLE
Fix to the image helper

### DIFF
--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -1,7 +1,7 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-$communityStoreImageHelper = $app->make('cs/helper/image', ['single_product']);
+$communityStoreImageHelper = $app->make('cs/helper/image', ['resizingScheme' => 'single_product']);
 $csm = $app->make('cs/helper/multilingual');
 
 if (is_object($product) && $product->isActive()) {

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -5,7 +5,14 @@ defined('C5_EXECUTE') or die("Access Denied.");
 // with the crop property set to true since default is false
 $legacyThumbProps = new \stdClass();
 $legacyThumbProps->crop = true;
-$communityStoreImageHelper = $app->make('cs/helper/image', ['product_list', null, $legacyThumbProps]);
+$communityStoreImageHelper = $app->make(
+    'cs/helper/image',
+    [
+        'resizingScheme' => 'product_list',
+        'thumbTypeHandle' => null,
+        'legacyThumbProps' => $legacyThumbProps
+    ]
+);
 $csm = $app->make('cs/helper/multilingual');
 
 $c = \Concrete\Core\Page\Page::getCurrentPage();

--- a/controller.php
+++ b/controller.php
@@ -134,12 +134,19 @@ class Controller extends Package
     public function registerHelpers()
     {
         $singletons = [
-            'cs/helper/image' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image',
             'cs/helper/multilingual' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Multilingual',
+        ];
+
+        $binds = [
+            'cs/helper/image' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image',
         ];
 
         foreach ($singletons as $key => $value) {
             $this->app->singleton($key, $value);
+        }
+
+        foreach ($binds as $key => $value) {
+            $this->app->bind($key, $value);
         }
     }
 

--- a/elements/product_modal.php
+++ b/elements/product_modal.php
@@ -4,7 +4,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\
 
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 
-$communityStoreImageHelper = $app->make('cs/helper/image', ['product_modal']);
+$communityStoreImageHelper = $app->make('cs/helper/image', ['resizingScheme' => 'product_modal']);
 $csm = $app->make('cs/helper/multilingual');
 $token = $app->make('token');
 ?>


### PR DESCRIPTION
This fixes 2 issues with the image helper.

First, because the image helper is registered as a singleton, it doesn't honor parameters after the first instantiation. This fixes that by registering it as a normal bind.

Second, now that its registration is fixed, this adds named parameters when the helper is used so it doesn't break in concrete v9.

Warning: any product or product list template using the helper without the named parameter will break the website when updating to concrete v9.

Updating CS alone won't hurt anything but some users might see unexpected changes to their website since the helper will now be doing its job properly and using the properly size images.

In my experience though images are also resized using CSS so I don't think anybody noticed their images were of the wrong size.
