### PR TITLE
Order cancel event

### DIFF
--- a/controllers/single_page/dashboard/store/orders.php
+++ b/controllers/single_page/dashboard/store/orders.php
@@ -14,6 +14,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderList;
 use Concrete\Package\CommunityStore\Entity\Attribute\Key\StoreOrderKey;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderStatus\OrderStatus;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as PaymentMethod;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Order\OrderEvent;
 
 class Orders extends DashboardPageController
 {
@@ -217,6 +218,8 @@ class Orders extends DashboardPageController
             $order->setCancelled(new \DateTime());
             $order->setCancelledByUID($user->getUserID());
             $order->save();
+            $event = new OrderEvent($order);
+            $event = \Events::dispatch(OrderEvent::ORDER_CANCELLED, $event);
 
             $this->flash('success', t('Order Cancelled'));
 

--- a/src/CommunityStore/Order/OrderEvent.php
+++ b/src/CommunityStore/Order/OrderEvent.php
@@ -11,6 +11,7 @@ class OrderEvent extends StoreEvent
     const ORDER_PAYMENT_COMPLETE = 'on_community_store_payment_complete';
     const ORDER_BEFORE_PAYMENT_COMPLETE = 'on_community_store_before_payment_complete';
     const ORDER_BEFORE_USER_ADD = 'on_community_store_before_user_add';
+    const ORDER_CANCELLED = 'on_community_store_order_cancelled';
 
     protected $event;
 


### PR DESCRIPTION
Can we get an event on order cancellation? Then 3rd party modules could trigger some actions if needed(like, cancel shipping or void a payment)