### PR TITLE
Addition of pvDisabled to ProductVariation, a boolean which prohibits…

### DIFF
--- a/blocks/community_product/view.js
+++ b/blocks/community_product/view.js
@@ -61,9 +61,16 @@ $(function () {
 
             if (variation['available']) {
                 pdb.find('.store-out-of-stock-label').addClass('hidden');
+                pdb.find('.store-not-available-label').addClass('hidden');
                 pdb.find('.store-btn-add-to-cart').removeClass('hidden');
             } else {
-                pdb.find('.store-out-of-stock-label').removeClass('hidden');
+                if (variation['disabled']) {
+                    pdb.find('.store-out-of-stock-label').addClass('hidden');
+                    pdb.find('.store-not-available-label').removeClass('hidden');
+                } else {
+                    pdb.find('.store-out-of-stock-label').removeClass('hidden');
+                    pdb.find('.store-not-available-label').addClass('hidden');
+                }
                 pdb.find('.store-btn-add-to-cart').addClass('hidden');
             }
 

--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -332,7 +332,8 @@ if (is_object($product) && $product->isActive()) {
                                         $disabled = false;
                                         $outOfStock = false;
                                         $firstOptionItem = true;
-                                        foreach ($optionItems as $optionItem) {
+                                        /** @var \Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductOption\ProductOptionItem[] $optionItems */
+										foreach ($optionItems as $optionItem) {
                                             $noValue = false;
                                             if (!$optionItem->isHidden()) {
                                                 $variation = $variationLookup[$optionItem->getID()];
@@ -477,6 +478,10 @@ if (is_object($product) && $product->isActive()) {
                             <?php $outOfStock = $csm->t($product->getOutOfStockMessage(), 'productOutOfStockMessage', $product->getID()); ?>
                             <?= $outOfStock ? h($outOfStock) : t("Out of Stock"); ?>
                         </p>
+                        <p class="store-not-available-label alert alert-warning hidden">
+							<?php $notAvailable = $csm->t('Not Available', 'productNotAvailableMessage', $product->getID()); ?>
+							<?= $notAvailable ? h($notAvailable) : t('Not Available') ?>
+                        </p>
                         <?php
                     } ?>
 
@@ -593,6 +598,7 @@ if (is_object($product) && $product->isActive()) {
                     'price' => $product->getPrice(),
                     'salePrice' => $product->getSalePrice(),
                     'available' => $variation->isSellable(),
+					'disabled' => $variation->getVariationDisabled(),
                     'maxCart' => $variation->getMaxCartQty(),
                     'imageThumb' => $thumb ? $thumb->src : '',
                     'image' => $imgObj ? $imgObj->getRelativePath() : '',

--- a/blocks/community_product_list/view.js
+++ b/blocks/community_product_list/view.js
@@ -60,9 +60,16 @@ $(function () {
 
             if (variation['available']) {
                 pdb.find('.store-out-of-stock-label').addClass('hidden');
+                pdb.find('.store-not-available-label').addClass('hidden');
                 pdb.find('.store-btn-add-to-cart').removeClass('hidden');
             } else {
-                pdb.find('.store-out-of-stock-label').removeClass('hidden');
+                if (variation['disabled']) {
+                    pdb.find('.store-out-of-stock-label').addClass('hidden');
+                    pdb.find('.store-not-available-label').removeClass('hidden');
+                } else {
+                    pdb.find('.store-out-of-stock-label').removeClass('hidden');
+                    pdb.find('.store-not-available-label').addClass('hidden');
+                }
                 pdb.find('.store-btn-add-to-cart').addClass('hidden');
             }
 

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -466,6 +466,10 @@ if (!$productsPerRow) {
                             <?= $outOfStock ? h($outOfStock) : t("Out of Stock"); ?>
                         </p>
 
+                        <p class="store-not-available-label alert alert-warning hidden">
+							<?php $notAvailable = $csm->t('Not Available', 'productNotAvailableMessage', $product->getID()); ?>
+							<?= $notAvailable ? h($notAvailable) : t('Not Available') ?>
+                        </p>
                         <?php
                     } ?>
 
@@ -487,6 +491,7 @@ if (!$productsPerRow) {
                                         'price' => $product->getPrice(),
                                         'salePrice' => $product->getSalePrice(),
                                         'available' => $variation->isSellable(),
+                                        'disabled' => $variation->getVariationDisabled(),
                                         'maxCart' => $variation->getMaxCartQty(),
                                         'imageThumb' => $thumb ? $thumb->src : '',
                                         'image' => $imgObj ? $imgObj->getRelativePath() : '',

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -5,6 +5,8 @@ use \Concrete\Core\Page\Page;
 use \Concrete\Core\Support\Facade\Url;
 use \Concrete\Core\Support\Facade\Config;
 use \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation;
+/** @var $variationLookup ProductVariation [] */
 
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 $listViews = ['view', 'updated', 'removed', 'success'];
@@ -1410,7 +1412,7 @@ if (version_compare($version, '9.0', '<')) {
                                 if ($product->hasVariations()) {
                                     $count = 0;
 
-                                    foreach ($comboOptions as $combinedOptions) {
+                                    foreach ($comboOptions as $comboKey => $combinedOptions) {
                                         ?>
                                         <div class="panel panel-default card-body">
                                             <div class="panel-heading card-heading">
@@ -1425,22 +1427,23 @@ if (version_compare($version, '9.0', '<')) {
                                                     echo '<span class="label label-primary">' . ($group ? $group->getName() : '') . ': ' . $optionItemLookup[$optionItemID]->getName() . '</span> ';
                                                 }
 
-                                                ?>
+												if (isset($variationLookup[implode('_', $comboIDs)])) {
+													$variation = $variationLookup[implode('_', $comboIDs)];
+													$varid = $variation->getID();
+												} else {
+													$variation = null;
+													$varid = '';
+												} ?>
+
+                                                <div class="form-group pull-right">
+													<?= $form->label('pvDisabled[' . $varid . ']', t('Disabled')); ?>
+													<?= $form->checkbox('pvDisabled[' . $varid . ']', 1, $variation ? $variation->getVariationDisabled() : false, ['data-combokey'=>$comboKey, 'class'=>'optionDisabled']) ?>
+                                                </div>
+
                                             </div>
 
-                                            <div class="panel-body card-body">
+                                            <div data-combokey="<?= $comboKey ?>" class="panel-body card-body"<?= ($variation && $variation->getVariationDisabled()) ? ' style="display:none"' :'' ?>">
                                                 <input type="hidden" name="option_combo[]" value="<?= implode('_', $comboIDs); ?>"/>
-
-                                                <?php
-
-                                                if (isset($variationLookup[implode('_', $comboIDs)])) {
-                                                    $variation = $variationLookup[implode('_', $comboIDs)];
-                                                    $varid = $variation->getID();
-                                                } else {
-                                                    $variation = null;
-                                                    $varid = '';
-                                                } ?>
-
 
                                                 <div class="row">
                                                     <div class="col-md-6">
@@ -1713,6 +1716,21 @@ if (version_compare($version, '9.0', '<')) {
 
                             $('#related-products').sortable({axis: 'y'});
 
+                            $('.optionDisabled').change(function () {
+                                var comboKey = $(this).data('combokey');
+                                var panelBody = null;
+                                $('.panel-body.card-body').each(function () {
+                                    if ($(this).data('combokey') === comboKey) {
+                                        panelBody = $(this);
+                                    }
+                                });
+
+                                if ($(this).is(':checked')) {
+                                    panelBody.slideUp();
+                                } else {
+                                    panelBody.slideDown();
+                                }
+                            });
                         });
 
                     </script>

--- a/src/CommunityStore/Product/ProductVariation/ProductVariation.php
+++ b/src/CommunityStore/Product/ProductVariation/ProductVariation.php
@@ -109,10 +109,25 @@ class ProductVariation
      */
     protected $pvSort;
 
+	/**
+	 * @ORM\Column(type="boolean",nullable=true)
+	 */
+	protected $pvDisabled;
+
     /**
      * @ORM\OneToMany(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariationOptionItem", mappedBy="variation", cascade={"persist"}))
      */
     protected $options;
+
+	public function getVariationDisabled()
+	{
+		return $this->pvDisabled ? 1 : 0;
+	}
+
+	public function setVariationDisabled($pvDisabled)
+	{
+		$this->pvDisabled = $pvDisabled ? 1 : 0;
+	}
 
     public function getVariationFID()
     {
@@ -143,6 +158,9 @@ class ProductVariation
         $this->options = new ArrayCollection();
     }
 
+	/**
+	 * @return ArrayCollection | ProductVariationOptionItem[]
+	 */
     public function getOptions()
     {
         return $this->options;
@@ -456,6 +474,9 @@ class ProductVariation
             return false;
         }
 
+        if ($this->getVariationDisabled()) {
+        	return false;
+		}
 
         if ($this->isUnlimited() || $this->getStockLevel() > 0) {
             return true;
@@ -524,6 +545,7 @@ class ProductVariation
                         'pvHeight' => '',
                         'pvLength' => '',
                         'pvSort' => $sort,
+                        'pvDisabled' => 0,
                          true, ]
                     );
 
@@ -556,6 +578,11 @@ class ProductVariation
                     $variation->setVariationLength($data['pvLength'][$key]);
                     $variation->setVariationPackageData($data['pvPackageData'][$key]);
                     $variation->setVariationSort($sort);
+                    if (isset($data['pvDisabled'][$key])) {
+						$variation->setVariationDisabled(1);
+					} else {
+                    	$variation->setVariationDisabled(0);
+					}
                     $variation->setProduct($product);
                     $variation->save(true);
 
@@ -597,6 +624,9 @@ class ProductVariation
         }
     }
 
+    /**
+	 * @return ProductVariation | null
+	 */
     public static function getByID($pvID)
     {
         $em = dbORM::entityManager();

--- a/src/CommunityStore/Utilities/Multilingual.php
+++ b/src/CommunityStore/Utilities/Multilingual.php
@@ -49,6 +49,7 @@ class Multilingual
      *  productQuantityLabel
      *  productAddToCartText
      *  productOutOfStockMessage
+     *  productNotAvailableMessage
      *  productAttributeName
      *  productAttributeLabel
      *  productAttributeValue
@@ -98,11 +99,17 @@ class Multilingual
 
             if ($productID) {
                 if ($useCommon) {
-                    if ($context == 'productQuantityLabel' || $context == 'productAddToCartText' || $context == 'productOutOfStockMessage') {
-                        $query->andWhere('t.pID = :pid or (t.originalText = :text)')->setParameter('pid', $productID)->setParameter('text', $text);
-                    } else {
-                        $query->andWhere('t.pID = :pid or (t.pID is null)')->setParameter('pid', $productID);
-                    }
+					switch ($context) {
+						case 'productQuantityLabel':
+						case 'productAddToCartText':
+						case 'productOutOfStockMessage':
+						case 'productNotAvailableMessage':
+							$query->andWhere('t.pID = :pid or (t.originalText = :text)')->setParameter('pid', $productID)->setParameter('text', $text);
+							break;
+						default:
+							$query->andWhere('t.pID = :pid or (t.pID is null)')->setParameter('pid', $productID);
+							break;
+					}
                 } else {
                     $query->andWhere('t.pID = :pid')->setParameter('pid', $productID);
                 }


### PR DESCRIPTION
Addition of pvDisabled to ProductVariation, a boolean which prohibits disables a variation and stops it being sellable, but with a different message to "Out of Stock". This is intended for products with multiple options where some combinations of options do not exist, e.g. a red shirt is never available in XS size. Setting this checkbox also collapses the option in the product editor for a more compact view. Issue #651