### PR TITLE
shallowClone should be public

### DIFF
--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -41,7 +41,7 @@ class Product
     // not stored, used for price/sku/etc lookup purposes
     public $priceAdjustment = 0;
     public $weightAdjustment = 0;
-    private $shallowClone = false;
+    public $shallowClone = false;
     public $variation;
 
     use ObjectTrait;


### PR DESCRIPTION
shallowClone should be public since it's being modified directly from other places(e.g. Cart.php, etc..)