### PR TITLE
Remove check that breaks adding shipping method

### DIFF
--- a/single_pages/dashboard/store/settings/shipping.php
+++ b/single_pages/dashboard/store/settings/shipping.php
@@ -97,7 +97,7 @@ if (in_array($controller->getAction(), $addViews)) {
 
                 </div>
                 <hr>
-                <?php isset($sm) ? $smt->renderDashboardForm($sm) : false; ?>
+                <?php $smt->renderDashboardForm($sm) ?>
             </div>
         </div>
 


### PR DESCRIPTION
This form could be rendered without $sm(e.g. you add a new shipping method), but it still should show shipping-method-specific fields, otherwise you can't even standard methods(e.g. flat rate). This check prevents rendering shipping-method-specific fields.