### PR TITLE
Change SKU with option selection + bug fix

### DIFF
--- a/blocks/community_product/form.php
+++ b/blocks/community_product/form.php
@@ -151,7 +151,7 @@
             },
             minimumInputLength: 2,
             initSelection: function(element, callback) {
-                callback({id: <?= ($pID ?? 0); ?>, text: <?= (isset($product) ? json_encode($product->getName()) : "''"); ?> });
+                callback({id: <?= ($pID ?? 0); ?>, text: <?= (isset($product) && is_object($product) ? json_encode($product->getName()) : "''"); ?> });
             }
         }).select2('val', []);
     });

--- a/blocks/community_product/view.js
+++ b/blocks/community_product/view.js
@@ -85,6 +85,14 @@ $(function () {
                     }
                 }
             }
+
+            if (variation['sku']) {
+                let skuHolder = pdb.find('.store-product-sku');
+                if (skuHolder) {
+                    $('span',skuHolder).html(variation['sku']);
+                }
+            }
+
             var quantityField = pdb.find('.store-product-qty');
             if (variation['maxCart'] !== false) {
                 quantityField.prop('max', variation['maxCart']);

--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -36,7 +36,7 @@ if (is_object($product) && $product->isActive()) {
                         <h1 class="store-product-name"
                             itemprop="name"><?= $csm->t($product->getName(), 'productName', $product->getID()); ?>
                          <?php if ($showProductSKU && $product->getSKU()) { ?>
-                             <small class="store-product-sku">(<?= h($product->getSKU()); ?>)</small>
+                             <small class="store-product-sku">(<span><?= h($product->getSKU()); ?></span>)</small>
                          <?php } ?>
                         </h1>
                         <meta itemprop="sku" content="<?= $product->getSKU(); ?>"/>
@@ -604,6 +604,7 @@ if (is_object($product) && $product->isActive()) {
                     'maxCart' => $variation->getMaxCartQty(),
                     'imageThumb' => $thumb ? $thumb->src : '',
                     'image' => $imgObj ? $imgObj->getRelativePath() : '',
+					'sku' => $variation->getVariationSKU(),
                     'saleTemplate'=> t('On Sale') .': <span class="store-sale-price"></span>&nbsp;' . t('was') . '&nbsp;<span class="store-original-price"></span>'
                 ];
 

--- a/blocks/community_product_list/view.js
+++ b/blocks/community_product_list/view.js
@@ -86,6 +86,13 @@ $(function () {
                 }
             }
 
+            if (variation['sku']) {
+                let skuHolder = pdb.find('.store-product-sku');
+                if (skuHolder) {
+                    $('span',skuHolder).html(variation['sku']);
+                }
+            }
+
             var quantityField = pdb.find('.store-product-qty');
             if (variation['maxCart'] !== false) {
                 quantityField.prop('max', variation['maxCart']);

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -118,7 +118,7 @@ $activeclass = '';
                         ?>
                         <h2 class="store-product-list-name"><?= $csm->t($product->getName(), 'productName', $product->getID()); ?>
                             <?php if ($showSKU && $product->getSKU()) { ?>
-                                <small class="store-product-sku">(<?= h($product->getSKU()); ?>)</small>
+                                <small class="store-product-sku">(<span><?= h($product->getSKU()); ?></span>)</small>
                             <?php } ?>
                         </h2>
                         <?php
@@ -497,6 +497,7 @@ $activeclass = '';
                                         'maxCart' => $variation->getMaxCartQty(),
                                         'imageThumb' => $thumb ? $thumb->src : '',
                                         'image' => $imgObj ? $imgObj->getRelativePath() : '',
+                                        'sku' => $variation->getVariationSKU(),
                                         'saleTemplate'=>'<span class="store-sale-price"></span>&nbsp;' . t('was') . '&nbsp;<span class="store-original-price"></span>'
                                         ];
 


### PR DESCRIPTION
Fix issue (community_product/form.php:154 Call to a member function getName() on bool) with editing product block introduced in 5cec6bf5664b7b5028d7771ae588b29d2d513884. Product is defined but is false, hence the exception.

For products with options, ensure the SKU shown matches that of the option in the same manner as images and price etc. It was necessary to wrap the actual SKU itself inside a span tag so that the () surrounding it didn't get eaten.