### PR TITLE
Fix issue with the product option "Hide" checkbox

### DIFF
--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -1335,7 +1335,7 @@ if (version_compare($version, '9.0', '<')) {
 
                         // add handler for hide checkbox, to adjust hidden value when changed
                         $(document).on('change', '.optionHiddenToggle', function () {
-                            $(this).prev().val(($(this).prop('checked') ? '1' : '0'));
+                            $('input[type=hidden]',$(this).closest('div.form-check-inline')).val(($(this).prop('checked') ? '1' : '0'));
                         });
 
                         $(function () {


### PR DESCRIPTION
The js code that's supposed to set the hidden form element associated with each product option "Hide" checkbox, didn't work because it was using the .prev() selector which looks for a previous sibling. This fails due to the checkbox being the only child of the label element which has no siblings.