### PR TITLE
Add TaxEvent Class and on_community_store_tax_calculate event

### DIFF
--- a/src/CommunityStore/Tax/TaxEvent.php
+++ b/src/CommunityStore/Tax/TaxEvent.php
@@ -1,0 +1,32 @@
+<?php
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Tax;
+
+use Concrete\Package\CommunityStore\Src\CommunityStore\Event\Event as StoreEvent;
+
+class TaxEvent extends StoreEvent
+{
+
+    private $updatedRate = null;
+    private $updatedLabel = null;
+
+    public function getUpdatedRate()
+    {
+        return $this->updatedRate;
+    }
+
+    public function setUpdatedRate($rate)
+    {
+        $this->updatedRate = $rate;
+    }
+
+    public function setUpdatedLabel($label)
+    {
+        $this->updatedLabel = $label;
+    }
+
+    public function getUpdatedLabel()
+    {
+        return($this->updatedLabel);
+    }
+
+}


### PR DESCRIPTION
The TaxEvent class and on_community_store_tax_calculate event alters the tax calculation on the fly so that other add-ons can change the tax rate based on external APIs and the like.

Feel free to suggest improvements!